### PR TITLE
Character

### DIFF
--- a/src/converter.rs
+++ b/src/converter.rs
@@ -10,7 +10,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// A converter can be used to restrict a character of a type to a certain
 /// alphabet.
-pub trait Converter<T> {
+pub trait Converter<T>
+where
+    T: Character,
+{
     /// Convert a character to a new character in the restricted alphabet.
     fn convert(&self, c: T) -> T;
     /// Convert a character back to the original character.
@@ -27,7 +30,10 @@ pub trait Converter<T> {
 ///
 /// The null (zero) character is handled separately and is always accepted.
 #[derive(Serialize, Deserialize)]
-pub struct RangeConverter<T> {
+pub struct RangeConverter<T>
+where
+    T: Character,
+{
     min: T,
     max: T,
 }
@@ -84,7 +90,10 @@ impl IdConverter {
     }
 }
 
-impl<T> Converter<T> for IdConverter {
+impl<T> Converter<T> for IdConverter
+where
+    T: Character,
+{
     fn convert(&self, c: T) -> T {
         c
     }
@@ -97,7 +106,10 @@ impl<T> Converter<T> for IdConverter {
 }
 
 /// A way to obtain the converter for a given index.
-pub trait IndexWithConverter<T> {
+pub trait IndexWithConverter<T>
+where
+    T: Character,
+{
     /// The converter type.
     type C: Converter<T>;
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,12 +1,11 @@
 use crate::converter::{Converter, IndexWithConverter};
 
-#[cfg(doc)]
 use crate::character::Character;
 
 /// A search index that can be searched backwards.
 pub trait BackwardIterableIndex: Sized {
     /// A [`Character`] type.
-    type T: Copy + Clone;
+    type T: Character;
 
     fn get_l(&self, i: u64) -> Self::T;
     fn lf_map(&self, i: u64) -> u64;
@@ -30,7 +29,7 @@ where
 
 impl<T, I> Iterator for BackwardIterator<'_, I>
 where
-    T: Copy + Clone,
+    T: Character,
     I: BackwardIterableIndex<T = T> + IndexWithConverter<T>,
 {
     type Item = <I as BackwardIterableIndex>::T;
@@ -44,7 +43,7 @@ where
 /// A search index that can be searched forwards.
 pub trait ForwardIterableIndex: Sized {
     /// A [`Character`] type.
-    type T: Copy + Clone;
+    type T: Character;
 
     fn get_f(&self, i: u64) -> Self::T;
     fn fl_map(&self, i: u64) -> u64;
@@ -68,7 +67,7 @@ where
 
 impl<T, I> Iterator for ForwardIterator<'_, I>
 where
-    T: Copy + Clone,
+    T: Character,
     I: ForwardIterableIndex<T = T> + IndexWithConverter<T>,
 {
     type Item = <I as ForwardIterableIndex>::T;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![warn(missing_docs)]
-
 //! This crate provides implementations of *FM-Index* and its variants.
 //!
 //! FM-Index, originally proposed by Paolo Ferragina and Giovanni Manzini [^1],
@@ -132,6 +130,7 @@
 //!     String Processing and Information Retrieval. SPIRE 2012.
 //!     <https://doi.org/10.1007/978-3-642-34109-0_18>
 #![allow(clippy::len_without_is_empty)]
+#![warn(missing_docs)]
 
 pub mod converter;
 pub mod suffix_array;

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -14,7 +14,10 @@ use vers_vecs::{BitVec, RsVec, WaveletMatrix};
 ///
 /// This can be more space-efficient than the FM-index, but is slower.
 #[derive(Serialize, Deserialize)]
-pub struct RLFMIndex<T, C, S> {
+pub struct RLFMIndex<T, C, S>
+where
+    T: Character,
+{
     converter: C,
     suffix_array: S,
     s: WaveletMatrix,
@@ -121,7 +124,10 @@ where
     }
 }
 
-impl<T, C> RLFMIndex<T, C, ()> {
+impl<T, C> RLFMIndex<T, C, ()>
+where
+    T: Character,
+{
     /// Heap size of the index.
     ///
     /// No suffix array information is stored in this index.
@@ -136,6 +142,7 @@ impl<T, C> RLFMIndex<T, C, ()> {
 
 impl<T, C, S> RLFMIndex<T, C, S>
 where
+    T: Character,
     S: PartialArray,
 {
     /// The size on the heap of the FM-Index.
@@ -261,6 +268,7 @@ where
 
 impl<T, C, S> IndexWithConverter<T> for RLFMIndex<T, C, S>
 where
+    T: Character,
     C: Converter<T>,
 {
     type C = C;

--- a/src/sais.rs
+++ b/src/sais.rs
@@ -6,11 +6,14 @@ use std::fmt::Debug;
 
 use vers_vecs::BitVec;
 
-use crate::converter::{Converter, IdConverter};
+use crate::{
+    converter::{Converter, IdConverter},
+    Character,
+};
 
 pub fn count_chars<T, C, K>(text: K, converter: &C) -> Vec<u64>
 where
-    T: Copy + Clone + Into<u64>,
+    T: Character,
     K: AsRef<[T]>,
     C: Converter<T>,
 {
@@ -84,7 +87,7 @@ fn is_lms(types: &BitVec, i: u64) -> bool {
 
 fn induced_sort<T, K, C>(text: K, converter: &C, types: &BitVec, occs: &[u64], sa: &mut [u64])
 where
-    T: Into<u64> + Copy + Clone + Ord,
+    T: Character,
     K: AsRef<[T]>,
     C: Converter<T>,
 {
@@ -115,7 +118,7 @@ where
 
 pub fn sais<T, C, K>(text: K, converter: &C) -> Vec<u64>
 where
-    T: Into<u64> + Copy + Clone + Ord + Debug,
+    T: Character,
     K: AsRef<[T]>,
     C: Converter<T>,
 {
@@ -138,7 +141,7 @@ where
 #[allow(clippy::cognitive_complexity)]
 fn sais_sub<T, C, K>(text: K, sa: &mut [u64], converter: &C)
 where
-    T: Into<u64> + Copy + Clone + Ord + Debug,
+    T: Character,
     K: AsRef<[T]>,
     C: Converter<T>,
 {


### PR DESCRIPTION
Simplify the trait bounds by using `Character` in more places. This theoretically breaks some loose coupling but in practice I think it makes life more clear - `Character` is a fundamental concept to this library.