### PR TITLE
Refine api

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ fm-index = "0.2"
 ## Example
 ```rust
 use fm_index::converter::RangeConverter;
-use fm_index::suffix_array::SuffixOrderSampler;
-use fm_index::{BackwardSearchIndex, FMIndex};
+use fm_index::FMIndex;
 
 // Prepare a text string to search for patterns.
 let text = concat!(
@@ -45,12 +44,15 @@ let text = concat!(
 // `' '` ~ `'~'` represents a range of ASCII printable characters.
 let converter = RangeConverter::new(b' ', b'~');
 
-// To perform locate queries, we need to retain suffix array generated in the construction phase.
-// However, we don't need the whole array since we can interpolate missing elements in a suffix array from others.
-// A sampler will _sieve_ a suffix array for this purpose.
-// You can also use `NullSampler` if you don't perform location queries (disabled in type-level).
-let sampler = SuffixOrderSampler::new().level(2);
-let index = FMIndex::new(text, converter, sampler);
+// To perform locate queries, we need to use some storage. How much storage
+// is used depends on the `level` arguments passed. `0` retains the full
+// information, but we don't need the whole array since we can interpolate
+// missing elements in a suffix array from others. A sampler will _sieve_ a
+// suffix array for this purpose. Here we use a `level` of 2, store 1/4th of the 
+// data.
+// You can also use `FMIndex::count_only()` if you don't perform location
+// queries (disabled in type-level).
+let index = FMIndex::new(text, converter, 2);
 
 // Search for a pattern string.
 let pattern = "dolor";

--- a/README.md
+++ b/README.md
@@ -112,15 +112,10 @@ It consists of
 - an array of size _O(σ)_ (_σ_: number of characters) which stores the number
   of characters smaller than a given character in run heads
 
-
-## Background
-
-
 ## Reference
 
 [^1]: Ferragina, P., & Manzini, G. (2000). Opportunistic data structures with
-applications. Annual Symposium on Foundations of Computer Science -
-Proceedings, 390–398. <https://doi.org/10.1109/sfcs.2000.892127>
+applications. Annual Symposium on Foundations of Computer Science \- Proceedings, 390–398. <https://doi.org/10.1109/sfcs.2000.892127>
 
 [^2]: Mäkinen, V., & Navarro, G. (2005). Succinct suffix arrays based on
 run-length encoding. In Lecture Notes in Computer Science (Vol. 3537).

--- a/benches/construction.rs
+++ b/benches/construction.rs
@@ -15,7 +15,7 @@ pub fn bench(c: &mut Criterion) {
             b.iter_batched(
                 || common::binary_text_set(n, 0.5),
                 |(text, converter)| {
-                    FMIndex::new(text, converter, NullSampler::new());
+                    FMIndex::count_only(text, converter);
                 },
                 BatchSize::SmallInput,
             )

--- a/benches/construction.rs
+++ b/benches/construction.rs
@@ -1,4 +1,3 @@
-use fm_index::suffix_array::NullSampler;
 use fm_index::{FMIndex, RLFMIndex};
 
 use criterion::{criterion_group, criterion_main};
@@ -25,7 +24,7 @@ pub fn bench(c: &mut Criterion) {
             b.iter_batched(
                 || common::binary_text_set(n, 0.5),
                 |(text, converter)| {
-                    RLFMIndex::new(text, converter, NullSampler::new());
+                    RLFMIndex::count_only(text, converter);
                 },
                 BatchSize::SmallInput,
             )

--- a/benches/count.rs
+++ b/benches/count.rs
@@ -13,7 +13,7 @@ fn prepare_fmindex(
 ) -> (impl BackwardSearchIndex<T = u8>, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
-    (FMIndex::new(text, converter, NullSampler::new()), patterns)
+    (FMIndex::count_only(text, converter), patterns)
 }
 
 fn prepare_rlfmindex(

--- a/benches/count.rs
+++ b/benches/count.rs
@@ -1,25 +1,17 @@
-use fm_index::{BackwardSearchIndex, FMIndex, RLFMIndex};
+use fm_index::{FMIndex, RLFMIndex, SearchIndex};
 
 use criterion::{criterion_group, criterion_main};
 use criterion::{AxisScale, BatchSize, BenchmarkId, Criterion, PlotConfiguration, Throughput};
 
 mod common;
 
-fn prepare_fmindex(
-    len: usize,
-    prob: f64,
-    m: usize,
-) -> (impl BackwardSearchIndex<T = u8>, Vec<String>) {
+fn prepare_fmindex(len: usize, prob: f64, m: usize) -> (impl SearchIndex<T = u8>, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (FMIndex::count_only(text, converter), patterns)
 }
 
-fn prepare_rlfmindex(
-    len: usize,
-    prob: f64,
-    m: usize,
-) -> (impl BackwardSearchIndex<T = u8>, Vec<String>) {
+fn prepare_rlfmindex(len: usize, prob: f64, m: usize) -> (impl SearchIndex<T = u8>, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (RLFMIndex::count_only(text, converter), patterns)
@@ -38,7 +30,7 @@ pub fn bench(c: &mut Criterion) {
                 || prepare_fmindex(n, prob, m),
                 |(index, patterns)| {
                     for pattern in patterns {
-                        index.search_backward(pattern).count();
+                        index.search(pattern).count();
                     }
                 },
                 BatchSize::SmallInput,
@@ -50,7 +42,7 @@ pub fn bench(c: &mut Criterion) {
                 || prepare_rlfmindex(n, prob, m),
                 |(index, patterns)| {
                     for pattern in patterns {
-                        index.search_backward(pattern).count();
+                        index.search(pattern).count();
                     }
                 },
                 BatchSize::SmallInput,

--- a/benches/count.rs
+++ b/benches/count.rs
@@ -1,4 +1,3 @@
-use fm_index::suffix_array::NullSampler;
 use fm_index::{BackwardSearchIndex, FMIndex, RLFMIndex};
 
 use criterion::{criterion_group, criterion_main};
@@ -23,10 +22,7 @@ fn prepare_rlfmindex(
 ) -> (impl BackwardSearchIndex<T = u8>, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
-    (
-        RLFMIndex::new(text, converter, NullSampler::new()),
-        patterns,
-    )
+    (RLFMIndex::count_only(text, converter), patterns)
 }
 
 pub fn bench(c: &mut Criterion) {

--- a/benches/locate.rs
+++ b/benches/locate.rs
@@ -1,4 +1,4 @@
-use fm_index::suffix_array::{Locatable, SuffixOrderSampler};
+use fm_index::suffix_array::Locatable;
 use fm_index::{BackwardSearchIndex, FMIndex, RLFMIndex};
 
 use criterion::{criterion_group, criterion_main};
@@ -25,10 +25,7 @@ fn prepare_rlfmindex(
 ) -> (impl BackwardSearchIndex<T = u8> + Locatable, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
-    (
-        RLFMIndex::new(text, converter, SuffixOrderSampler::new().level(l)),
-        patterns,
-    )
+    (RLFMIndex::new(text, converter, l), patterns)
 }
 
 pub fn bench(c: &mut Criterion) {

--- a/benches/locate.rs
+++ b/benches/locate.rs
@@ -1,4 +1,4 @@
-use fm_index::suffix_array::{IndexWithSA, SuffixOrderSampler};
+use fm_index::suffix_array::{Locatable, SuffixOrderSampler};
 use fm_index::{BackwardSearchIndex, FMIndex, RLFMIndex};
 
 use criterion::{criterion_group, criterion_main};
@@ -11,7 +11,7 @@ fn prepare_fmindex(
     prob: f64,
     m: usize,
     l: usize,
-) -> (impl BackwardSearchIndex<T = u8> + IndexWithSA, Vec<String>) {
+) -> (impl BackwardSearchIndex<T = u8> + Locatable, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (
@@ -25,7 +25,7 @@ fn prepare_rlfmindex(
     prob: f64,
     m: usize,
     l: usize,
-) -> (impl BackwardSearchIndex<T = u8> + IndexWithSA, Vec<String>) {
+) -> (impl BackwardSearchIndex<T = u8> + Locatable, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (

--- a/benches/locate.rs
+++ b/benches/locate.rs
@@ -1,4 +1,4 @@
-use fm_index::suffix_array::Locatable;
+use fm_index::suffix_array::HasPosition;
 use fm_index::{FMIndex, RLFMIndex, SearchIndex};
 
 use criterion::{criterion_group, criterion_main};
@@ -11,7 +11,7 @@ fn prepare_fmindex(
     prob: f64,
     m: usize,
     l: usize,
-) -> (impl SearchIndex<T = u8> + Locatable, Vec<String>) {
+) -> (impl SearchIndex<T = u8> + HasPosition, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (FMIndex::new(text, converter, l), patterns)
@@ -22,7 +22,7 @@ fn prepare_rlfmindex(
     prob: f64,
     m: usize,
     l: usize,
-) -> (impl SearchIndex<T = u8> + Locatable, Vec<String>) {
+) -> (impl SearchIndex<T = u8> + HasPosition, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (RLFMIndex::new(text, converter, l), patterns)

--- a/benches/locate.rs
+++ b/benches/locate.rs
@@ -1,5 +1,5 @@
 use fm_index::suffix_array::Locatable;
-use fm_index::{BackwardSearchIndex, FMIndex, RLFMIndex};
+use fm_index::{FMIndex, RLFMIndex, SearchIndex};
 
 use criterion::{criterion_group, criterion_main};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
@@ -11,7 +11,7 @@ fn prepare_fmindex(
     prob: f64,
     m: usize,
     l: usize,
-) -> (impl BackwardSearchIndex<T = u8> + Locatable, Vec<String>) {
+) -> (impl SearchIndex<T = u8> + Locatable, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (FMIndex::new(text, converter, l), patterns)
@@ -22,7 +22,7 @@ fn prepare_rlfmindex(
     prob: f64,
     m: usize,
     l: usize,
-) -> (impl BackwardSearchIndex<T = u8> + Locatable, Vec<String>) {
+) -> (impl SearchIndex<T = u8> + Locatable, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (RLFMIndex::new(text, converter, l), patterns)
@@ -40,7 +40,7 @@ pub fn bench(c: &mut Criterion) {
                 || prepare_fmindex(n, prob, m, l),
                 |(index, patterns)| {
                     for pattern in patterns {
-                        index.search_backward(pattern).locate();
+                        index.search(pattern).locate();
                     }
                 },
                 BatchSize::SmallInput,
@@ -52,7 +52,7 @@ pub fn bench(c: &mut Criterion) {
                 || prepare_rlfmindex(n, prob, m, l),
                 |(index, patterns)| {
                     for pattern in patterns {
-                        index.search_backward(pattern).locate();
+                        index.search(pattern).locate();
                     }
                 },
                 BatchSize::SmallInput,

--- a/benches/locate.rs
+++ b/benches/locate.rs
@@ -14,10 +14,7 @@ fn prepare_fmindex(
 ) -> (impl BackwardSearchIndex<T = u8> + Locatable, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
-    (
-        FMIndex::new(text, converter, SuffixOrderSampler::new().level(l)),
-        patterns,
-    )
+    (FMIndex::new(text, converter, l), patterns)
 }
 
 fn prepare_rlfmindex(

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -47,6 +47,6 @@ fn main() {
     assert_eq!(postfix, b"dolore magna aliqua.".to_owned());
 
     // Search can be chained backward.
-    let search_chained = search.search_backward("et ");
+    let search_chained = search.search("et ");
     assert_eq!(search_chained.count(), 1);
 }

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,5 +1,5 @@
 use fm_index::converter::RangeConverter;
-use fm_index::{BackwardSearchIndex, FMIndex};
+use fm_index::FMIndex;
 
 fn main() {
     // Prepare a text string to search for patterns.
@@ -25,7 +25,7 @@ fn main() {
 
     // Search for a pattern string.
     let pattern = "dolor";
-    let search = index.search_backward(pattern);
+    let search = index.search(pattern);
 
     // Count the number of occurrences.
     let n = search.count();

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,5 +1,4 @@
 use fm_index::converter::RangeConverter;
-use fm_index::suffix_array::SuffixOrderSampler;
 use fm_index::{BackwardSearchIndex, FMIndex};
 
 fn main() {
@@ -15,12 +14,14 @@ fn main() {
     // `' '` ~ `'~'` represents a range of ASCII printable characters.
     let converter = RangeConverter::new(b' ', b'~');
 
-    // To perform locate queries, we need to retain suffix array generated in the construction phase.
-    // However, we don't need the whole array since we can interpolate missing elements in a suffix array from others.
-    // A sampler will _sieve_ a suffix array for this purpose.
-    // You can also use `NullSampler` if you don't perform location queries (disabled in type-level).
-    let sampler = SuffixOrderSampler::new().level(2);
-    let index = FMIndex::new(text, converter, sampler);
+    // To perform locate queries, we need to use some storage. How much storage
+    // is used depends on the `level` arguments passed. `0` retains the full
+    // information, but we don't need the whole array since we can interpolate
+    // missing elements in a suffix array from others. A sampler will _sieve_ a
+    // suffix array for this purpose.
+    // You can also use `FMIndex::count_only()` if you don't perform location
+    // queries (disabled in type-level).
+    let index = FMIndex::new(text, converter, 2);
 
     // Search for a pattern string.
     let pattern = "dolor";

--- a/src/character.rs
+++ b/src/character.rs
@@ -16,6 +16,13 @@ pub trait Character: Into<u64> + Copy + Clone + Num + Ord + std::fmt::Debug {
     fn from_u64(n: u64) -> Self;
 }
 
+pub(crate) fn prepare_text<T: Character>(mut text: Vec<T>) -> Vec<T> {
+    if !text[text.len() - 1].is_zero() {
+        text.push(T::zero());
+    }
+    text
+}
+
 macro_rules! impl_character {
     ($t:ty) => {
         impl Character for $t {

--- a/src/converter.rs
+++ b/src/converter.rs
@@ -10,7 +10,10 @@ use serde::{Deserialize, Serialize};
 ///
 /// A converter can be used to restrict a character of a type to a certain
 /// alphabet.
-pub trait Converter<T> {
+pub trait Converter<T>
+where
+    T: Character,
+{
     /// Convert a character to a new character in the restricted alphabet.
     fn convert(&self, c: T) -> T;
     /// Convert a character back to the original character.
@@ -27,7 +30,10 @@ pub trait Converter<T> {
 ///
 /// The null (zero) character is handled separately and is always accepted.
 #[derive(Serialize, Deserialize)]
-pub struct RangeConverter<T> {
+pub struct RangeConverter<T>
+where
+    T: Character,
+{
     min: T,
     max: T,
 }
@@ -84,7 +90,10 @@ impl IdConverter {
     }
 }
 
-impl<T> Converter<T> for IdConverter {
+impl<T> Converter<T> for IdConverter
+where
+    T: Character,
+{
     fn convert(&self, c: T) -> T {
         c
     }
@@ -97,7 +106,10 @@ impl<T> Converter<T> for IdConverter {
 }
 
 /// A way to obtain the converter for a given index.
-pub trait IndexWithConverter<T> {
+pub trait IndexWithConverter<T>
+where
+    T: Character,
+{
     /// The converter type.
     type C: Converter<T>;
 

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -3,9 +3,7 @@ use crate::character::Character;
 use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::sais;
-use crate::suffix_array::{
-    private, ArraySampler, Locatable, NullSampler, SuffixOrderSampledArray, SuffixOrderSampler,
-};
+use crate::suffix_array::{self, private, Locatable, SuffixOrderSampledArray};
 use crate::util;
 use crate::{BackwardIterableIndex, ForwardIterableIndex};
 
@@ -84,12 +82,11 @@ where
         let sa = sais::sais(&text, &converter);
         let bw = Self::wavelet_matrix(text, &sa, &converter);
 
-        let sampler = SuffixOrderSampler::new().level(level);
         FMIndex {
             cs,
             bw,
             converter,
-            suffix_array: sampler.sample::<private::Local>(sa),
+            suffix_array: suffix_array::sample(sa, level),
             _t: std::marker::PhantomData::<T>,
         }
     }
@@ -257,7 +254,6 @@ mod tests {
     use super::*;
     use crate::converter::RangeConverter;
     use crate::search::BackwardSearchIndex;
-    use crate::suffix_array::{NullSampler, SuffixOrderSampler};
 
     #[test]
     fn test_small() {

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -3,7 +3,7 @@ use crate::character::Character;
 use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::sais;
-use crate::suffix_array::{ArraySampler, Locatable, SuffixOrderSampledArray};
+use crate::suffix_array::{private, ArraySampler, Locatable, SuffixOrderSampledArray};
 use crate::util;
 use crate::{BackwardIterableIndex, ForwardIterableIndex};
 
@@ -173,7 +173,7 @@ where
     T: Character,
     C: Converter<T>,
 {
-    fn get_sa(&self, mut i: u64) -> u64 {
+    fn get_sa<L: private::IsLocal>(&self, mut i: u64) -> u64 {
         let mut steps = 0;
         loop {
             match self.suffix_array.get(i) {

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -66,7 +66,7 @@ where
             cs,
             bw,
             converter,
-            suffix_array: sampler.sample(sa),
+            suffix_array: sampler.sample::<private::Local>(sa),
             _t: std::marker::PhantomData::<T>,
         }
     }

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -3,7 +3,7 @@ use crate::character::Character;
 use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::sais;
-use crate::suffix_array::{ArraySampler, IndexWithSA, PartialArray};
+use crate::suffix_array::{ArraySampler, IndexWithSA, SuffixOrderSampledArray};
 use crate::util;
 use crate::{BackwardIterableIndex, ForwardIterableIndex};
 
@@ -88,10 +88,7 @@ impl<T, C> FMIndex<T, C, ()> {
     }
 }
 
-impl<T, C, S> FMIndex<T, C, S>
-where
-    S: PartialArray,
-{
+impl<T, C> FMIndex<T, C, SuffixOrderSampledArray> {
     /// The size on the heap of the FM-Index.
     ///
     /// Sampled suffix array data is stored in this index.
@@ -171,11 +168,10 @@ where
     }
 }
 
-impl<T, C, S> IndexWithSA for FMIndex<T, C, S>
+impl<T, C> IndexWithSA for FMIndex<T, C, SuffixOrderSampledArray>
 where
     T: Character,
     C: Converter<T>,
-    S: PartialArray,
 {
     fn get_sa(&self, mut i: u64) -> u64 {
         let mut steps = 0;

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -2,9 +2,9 @@ use crate::character::{prepare_text, Character};
 #[cfg(doc)]
 use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
-use crate::sais;
 use crate::search::SearchIndex;
-use crate::suffix_array::{self, private, Locatable, SuffixOrderSampledArray};
+use crate::suffix_array::{self, Locatable, SuffixOrderSampledArray};
+use crate::{sais, seal};
 use crate::{util, Search};
 use crate::{BackwardIterableIndex, ForwardIterableIndex};
 
@@ -219,7 +219,7 @@ where
     T: Character,
     C: Converter<T>,
 {
-    fn get_sa<L: private::IsLocal>(&self, mut i: u64) -> u64 {
+    fn get_sa<L: seal::IsLocal>(&self, mut i: u64) -> u64 {
         let mut steps = 0;
         loop {
             match self.suffix_array.get(i) {

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -3,7 +3,7 @@ use crate::character::Character;
 use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::sais;
-use crate::suffix_array::{ArraySampler, IndexWithSA, SuffixOrderSampledArray};
+use crate::suffix_array::{ArraySampler, Locatable, SuffixOrderSampledArray};
 use crate::util;
 use crate::{BackwardIterableIndex, ForwardIterableIndex};
 
@@ -168,7 +168,7 @@ where
     }
 }
 
-impl<T, C> IndexWithSA for FMIndex<T, C, SuffixOrderSampledArray>
+impl<T, C> Locatable for FMIndex<T, C, SuffixOrderSampledArray>
 where
     T: Character,
     C: Converter<T>,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,12 +1,11 @@
 use crate::converter::{Converter, IndexWithConverter};
 
-#[cfg(doc)]
 use crate::character::Character;
 
 /// A search index that can be searched backwards.
 pub trait BackwardIterableIndex: Sized {
     /// A [`Character`] type.
-    type T: Copy + Clone;
+    type T: Character;
 
     fn get_l(&self, i: u64) -> Self::T;
     fn lf_map(&self, i: u64) -> u64;
@@ -30,7 +29,7 @@ where
 
 impl<T, I> Iterator for BackwardIterator<'_, I>
 where
-    T: Copy + Clone,
+    T: Character,
     I: BackwardIterableIndex<T = T> + IndexWithConverter<T>,
 {
     type Item = <I as BackwardIterableIndex>::T;
@@ -44,7 +43,7 @@ where
 /// A search index that can be searched forwards.
 pub trait ForwardIterableIndex: Sized {
     /// A [`Character`] type.
-    type T: Copy + Clone;
+    type T: Character;
 
     fn get_f(&self, i: u64) -> Self::T;
     fn fl_map(&self, i: u64) -> u64;
@@ -68,7 +67,7 @@ where
 
 impl<T, I> Iterator for ForwardIterator<'_, I>
 where
-    T: Copy + Clone,
+    T: Character,
     I: ForwardIterableIndex<T = T> + IndexWithConverter<T>,
 {
     type Item = <I as ForwardIterableIndex>::T;

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,19 +1,25 @@
 use crate::converter::{Converter, IndexWithConverter};
 
 use crate::character::Character;
+use crate::seal;
 
 /// A search index that can be searched backwards.
 pub trait BackwardIterableIndex: Sized {
     /// A [`Character`] type.
     type T: Character;
 
-    fn get_l(&self, i: u64) -> Self::T;
-    fn lf_map(&self, i: u64) -> u64;
-    fn lf_map2(&self, c: Self::T, i: u64) -> u64;
-    fn len(&self) -> u64;
+    #[doc(hidden)]
+    fn get_l<L: seal::IsLocal>(&self, i: u64) -> Self::T;
+    #[doc(hidden)]
+    fn lf_map<L: seal::IsLocal>(&self, i: u64) -> u64;
+    #[doc(hidden)]
+    fn lf_map2<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64;
+    #[doc(hidden)]
+    fn len<L: seal::IsLocal>(&self) -> u64;
 
-    fn iter_backward(&self, i: u64) -> BackwardIterator<Self> {
-        debug_assert!(i < self.len());
+    #[doc(hidden)]
+    fn iter_backward<L: seal::IsLocal>(&self, i: u64) -> BackwardIterator<Self> {
+        debug_assert!(i < self.len::<seal::Local>());
         BackwardIterator { index: self, i }
     }
 }
@@ -34,8 +40,8 @@ where
 {
     type Item = <I as BackwardIterableIndex>::T;
     fn next(&mut self) -> Option<Self::Item> {
-        let c = self.index.get_l(self.i);
-        self.i = self.index.lf_map(self.i);
+        let c = self.index.get_l::<seal::Local>(self.i);
+        self.i = self.index.lf_map::<seal::Local>(self.i);
         Some(self.index.get_converter().convert_inv(c))
     }
 }
@@ -45,13 +51,18 @@ pub trait ForwardIterableIndex: Sized {
     /// A [`Character`] type.
     type T: Character;
 
-    fn get_f(&self, i: u64) -> Self::T;
-    fn fl_map(&self, i: u64) -> u64;
-    fn fl_map2(&self, c: Self::T, i: u64) -> u64;
-    fn len(&self) -> u64;
+    #[doc(hidden)]
+    fn get_f<L: seal::IsLocal>(&self, i: u64) -> Self::T;
+    #[doc(hidden)]
+    fn fl_map<L: seal::IsLocal>(&self, i: u64) -> u64;
+    #[doc(hidden)]
+    fn fl_map2<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64;
+    #[doc(hidden)]
+    fn len<L: seal::IsLocal>(&self) -> u64;
 
-    fn iter_forward(&self, i: u64) -> ForwardIterator<Self> {
-        debug_assert!(i < self.len());
+    #[doc(hidden)]
+    fn iter_forward<L: seal::IsLocal>(&self, i: u64) -> ForwardIterator<Self> {
+        debug_assert!(i < self.len::<L>());
         ForwardIterator { index: self, i }
     }
 }
@@ -72,8 +83,8 @@ where
 {
     type Item = <I as ForwardIterableIndex>::T;
     fn next(&mut self) -> Option<Self::Item> {
-        let c = self.index.get_f(self.i);
-        self.i = self.index.fl_map(self.i);
+        let c = self.index.get_f::<seal::Local>(self.i);
+        self.i = self.index.fl_map::<seal::Local>(self.i);
         Some(self.index.get_converter().convert_inv(c))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![warn(missing_docs)]
-
 //! This crate provides implementations of *FM-Index* and its variants.
 //!
 //! FM-Index, originally proposed by Paolo Ferragina and Giovanni Manzini [^1],
@@ -132,6 +130,7 @@
 //!     String Processing and Information Retrieval. SPIRE 2012.
 //!     <https://doi.org/10.1007/978-3-642-34109-0_18>
 #![allow(clippy::len_without_is_empty)]
+#![warn(missing_docs)]
 
 pub mod converter;
 pub mod suffix_array;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,12 +39,14 @@
 //! // `' '` ~ `'~'` represents a range of ASCII printable characters.
 //! let converter = RangeConverter::new(b' ', b'~');
 //!
-//! // To perform locate queries, we need to retain suffix array generated in the construction phase.
-//! // However, we don't need the whole array since we can interpolate missing elements in a suffix array from others.
-//! // A sampler will _sieve_ a suffix array for this purpose.
-//! // You can also use `NullSampler` if you don't perform location queries (disabled in type-level).
-//! let sampler = SuffixOrderSampler::new().level(2);
-//! let index = FMIndex::new(text, converter, sampler);
+//! // To perform locate queries, we need to use some storage. How much storage
+//! // is used depends on the `level` arguments passed. `0` retains the full
+//! // information, but we don't need the whole array since we can interpolate
+//! // missing elements in a suffix array from others. A sampler will _sieve_ a
+//! // suffix array for this purpose.
+//! // You can also use `FMIndex::count_only()` if you don't perform location
+//! // queries (disabled in type-level).
+//! let index = FMIndex::new(text, converter, 2);
 //!
 //! // Search for a pattern string.
 //! let pattern = "dolor";
@@ -114,8 +116,8 @@
 //! # Reference
 //!
 //! [^1]: Ferragina, P., & Manzini, G. (2000). Opportunistic data structures
-//!     with applications. Annual Symposium on Foundations of Computer Science - Proceedings,
-//!     390–398. <https://doi.org/10.1109/sfcs.2000.892127>
+//!     with applications. Annual Symposium on Foundations of Computer Science
+//!     - Proceedings, 390–398. <https://doi.org/10.1109/sfcs.2000.892127>
 //!
 //! [^2]: Mäkinen, V., & Navarro, G. (2005). Succinct suffix arrays based on
 //!     run-length encoding. In Lecture Notes in Computer Science (Vol. 3537).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,5 +150,5 @@ pub use crate::fm_index::FMIndex;
 pub use crate::rlfmi::RLFMIndex;
 
 pub use character::Character;
-pub use iter::{BackwardIterableIndex, ForwardIterableIndex};
+pub use iter::{BackwardIterableIndex, BackwardIterator, ForwardIterableIndex, ForwardIterator};
 pub use search::{Search, SearchIndex};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //! # Example
 //! ```
 //! use fm_index::converter::RangeConverter;
-//! use fm_index::suffix_array::SuffixOrderSampler;
 //! use fm_index::{BackwardSearchIndex, FMIndex};
 //!
 //! // Prepare a text string to search for patterns.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@
 //! assert_eq!(postfix, b"dolore magna aliqua.".to_owned());
 //!
 //! // Search can be chained backward.
-//! let search_chained = search.search_backward("et ");
+//! let search_chained = search.search("et ");
 //! assert_eq!(search_chained.count(), 1);
 //! ```
 //!
@@ -118,7 +118,7 @@
 //!
 //! [^1]: Ferragina, P., & Manzini, G. (2000). Opportunistic data structures
 //!     with applications. Annual Symposium on Foundations of Computer Science
-//!     - Proceedings, 390–398. <https://doi.org/10.1109/sfcs.2000.892127>
+//!     \- Proceedings, 390–398. <https://doi.org/10.1109/sfcs.2000.892127>
 //!
 //! [^2]: Mäkinen, V., & Navarro, G. (2005). Succinct suffix arrays based on
 //!     run-length encoding. In Lecture Notes in Computer Science (Vol. 3537).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! # Example
 //! ```
 //! use fm_index::converter::RangeConverter;
-//! use fm_index::{BackwardSearchIndex, FMIndex};
+//! use fm_index::FMIndex;
 //!
 //! // Prepare a text string to search for patterns.
 //! let text = concat!(
@@ -42,14 +42,16 @@
 //! // is used depends on the `level` arguments passed. `0` retains the full
 //! // information, but we don't need the whole array since we can interpolate
 //! // missing elements in a suffix array from others. A sampler will _sieve_ a
-//! // suffix array for this purpose.
+//! // suffix array for this purpose. Here we use a `level` of 2, store 1/4th of the
+//! // data.
+//! //
 //! // You can also use `FMIndex::count_only()` if you don't perform location
 //! // queries (disabled in type-level).
 //! let index = FMIndex::new(text, converter, 2);
 //!
 //! // Search for a pattern string.
 //! let pattern = "dolor";
-//! let search = index.search_backward(pattern);
+//! let search = index.search(pattern);
 //!
 //! // Count the number of occurrences.
 //! let n = search.count();
@@ -149,4 +151,4 @@ pub use crate::rlfmi::RLFMIndex;
 
 pub use character::Character;
 pub use iter::{BackwardIterableIndex, ForwardIterableIndex};
-pub use search::{BackwardSearchIndex, Search};
+pub use search::{Search, SearchIndex};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,6 +143,7 @@ mod fm_index;
 mod iter;
 mod rlfmi;
 mod sais;
+mod seal;
 mod search;
 mod util;
 

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -3,7 +3,7 @@ use crate::character::Character;
 use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::sais;
-use crate::suffix_array::{ArraySampler, IndexWithSA, PartialArray};
+use crate::suffix_array::{ArraySampler, IndexWithSA, SuffixOrderSampledArray};
 use crate::util;
 use crate::{BackwardIterableIndex, ForwardIterableIndex};
 
@@ -140,10 +140,9 @@ where
     }
 }
 
-impl<T, C, S> RLFMIndex<T, C, S>
+impl<T, C> RLFMIndex<T, C, SuffixOrderSampledArray>
 where
     T: Character,
-    S: PartialArray,
 {
     /// The size on the heap of the FM-Index.
     ///
@@ -244,11 +243,10 @@ where
     }
 }
 
-impl<T, C, S> IndexWithSA for RLFMIndex<T, C, S>
+impl<T, C> IndexWithSA for RLFMIndex<T, C, SuffixOrderSampledArray>
 where
     T: Character,
     C: Converter<T>,
-    S: PartialArray,
 {
     fn get_sa(&self, mut i: u64) -> u64 {
         let mut steps = 0;

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -3,9 +3,9 @@ use crate::character::{prepare_text, Character};
 use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::search::SearchIndex;
-use crate::suffix_array::{self, private, Locatable, SuffixOrderSampledArray};
-use crate::util;
+use crate::suffix_array::{self, Locatable, SuffixOrderSampledArray};
 use crate::{sais, Search};
+use crate::{seal, util};
 use crate::{BackwardIterableIndex, ForwardIterableIndex};
 
 use serde::{Deserialize, Serialize};
@@ -294,7 +294,7 @@ where
     T: Character,
     C: Converter<T>,
 {
-    fn get_sa<L: private::IsLocal>(&self, mut i: u64) -> u64 {
+    fn get_sa<L: seal::IsLocal>(&self, mut i: u64) -> u64 {
         let mut steps = 0;
         loop {
             match self.suffix_array.get(i) {

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -14,7 +14,10 @@ use vers_vecs::{BitVec, RsVec, WaveletMatrix};
 ///
 /// This can be more space-efficient than the FM-index, but is slower.
 #[derive(Serialize, Deserialize)]
-pub struct RLFMIndex<T, C, S> {
+pub struct RLFMIndex<T, C, S>
+where
+    T: Character,
+{
     converter: C,
     suffix_array: S,
     s: WaveletMatrix,
@@ -121,7 +124,10 @@ where
     }
 }
 
-impl<T, C> RLFMIndex<T, C, ()> {
+impl<T, C> RLFMIndex<T, C, ()>
+where
+    T: Character,
+{
     /// Heap size of the index.
     ///
     /// No suffix array information is stored in this index.
@@ -136,6 +142,7 @@ impl<T, C> RLFMIndex<T, C, ()> {
 
 impl<T, C, S> RLFMIndex<T, C, S>
 where
+    T: Character,
     S: PartialArray,
 {
     /// The size on the heap of the FM-Index.
@@ -261,6 +268,7 @@ where
 
 impl<T, C, S> IndexWithConverter<T> for RLFMIndex<T, C, S>
 where
+    T: Character,
     C: Converter<T>,
 {
     type C = C;

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -3,7 +3,7 @@ use crate::character::Character;
 use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::sais;
-use crate::suffix_array::{ArraySampler, IndexWithSA, SuffixOrderSampledArray};
+use crate::suffix_array::{ArraySampler, Locatable, SuffixOrderSampledArray};
 use crate::util;
 use crate::{BackwardIterableIndex, ForwardIterableIndex};
 
@@ -243,7 +243,7 @@ where
     }
 }
 
-impl<T, C> IndexWithSA for RLFMIndex<T, C, SuffixOrderSampledArray>
+impl<T, C> Locatable for RLFMIndex<T, C, SuffixOrderSampledArray>
 where
     T: Character,
     C: Converter<T>,

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -3,7 +3,7 @@ use crate::character::Character;
 use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::sais;
-use crate::suffix_array::{ArraySampler, Locatable, SuffixOrderSampledArray};
+use crate::suffix_array::{private, ArraySampler, Locatable, SuffixOrderSampledArray};
 use crate::util;
 use crate::{BackwardIterableIndex, ForwardIterableIndex};
 
@@ -248,7 +248,7 @@ where
     T: Character,
     C: Converter<T>,
 {
-    fn get_sa(&self, mut i: u64) -> u64 {
+    fn get_sa<L: private::IsLocal>(&self, mut i: u64) -> u64 {
         let mut steps = 0;
         loop {
             match self.suffix_array.get(i) {

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -98,7 +98,7 @@ where
         let bp = RsVec::from_bit_vec(bp);
         RLFMIndex {
             converter,
-            suffix_array: sampler.sample(sa),
+            suffix_array: sampler.sample::<private::Local>(sa),
             s,
             b,
             bp,

--- a/src/sais.rs
+++ b/src/sais.rs
@@ -1,9 +1,6 @@
 //! SA-IS implementation based on
 //!    Ge Nong, Sen Zhang, & Wai Hong Chan. (2010). Two Efficient Algorithms for Linear Time Suffix Array Construction.
 //!    IEEE Transactions on Computers, 60(10), 1471–1484. <https://doi.org/10.1109/tc.2010.188>
-
-use std::fmt::Debug;
-
 use vers_vecs::BitVec;
 
 use crate::{

--- a/src/sais.rs
+++ b/src/sais.rs
@@ -6,11 +6,14 @@ use std::fmt::Debug;
 
 use vers_vecs::BitVec;
 
-use crate::converter::{Converter, IdConverter};
+use crate::{
+    converter::{Converter, IdConverter},
+    Character,
+};
 
 pub fn count_chars<T, C, K>(text: K, converter: &C) -> Vec<u64>
 where
-    T: Copy + Clone + Into<u64>,
+    T: Character,
     K: AsRef<[T]>,
     C: Converter<T>,
 {
@@ -84,7 +87,7 @@ fn is_lms(types: &BitVec, i: u64) -> bool {
 
 fn induced_sort<T, K, C>(text: K, converter: &C, types: &BitVec, occs: &[u64], sa: &mut [u64])
 where
-    T: Into<u64> + Copy + Clone + Ord,
+    T: Character,
     K: AsRef<[T]>,
     C: Converter<T>,
 {
@@ -115,7 +118,7 @@ where
 
 pub fn sais<T, C, K>(text: K, converter: &C) -> Vec<u64>
 where
-    T: Into<u64> + Copy + Clone + Ord + Debug,
+    T: Character,
     K: AsRef<[T]>,
     C: Converter<T>,
 {
@@ -138,7 +141,7 @@ where
 #[allow(clippy::cognitive_complexity)]
 fn sais_sub<T, C, K>(text: K, sa: &mut [u64], converter: &C)
 where
-    T: Into<u64> + Copy + Clone + Ord + Debug,
+    T: Character,
     K: AsRef<[T]>,
     C: Converter<T>,
 {

--- a/src/seal.rs
+++ b/src/seal.rs
@@ -1,0 +1,15 @@
+// A way to have trait methods that are effectively private.
+//
+// They can only be used from this crate, but not outside, as long
+// as we don't publish anything in this module to the outside world.
+//
+// https://jack.wrenn.fyi/blog/private-trait-methods/
+
+// An effectively private type to encode locality. We make it uninhabited
+// so we *cannot* accidentally leak it.
+pub enum Local {}
+
+// We pair it with a 'sealed' trait that is *only* implemented for `Local`.
+pub trait IsLocal {}
+
+impl IsLocal for Local {}

--- a/src/search.rs
+++ b/src/search.rs
@@ -3,14 +3,21 @@ use crate::suffix_array::{private, Locatable};
 
 #[cfg(doc)]
 use crate::character::Character;
+#[cfg(doc)]
+use crate::fm_index::FMIndex;
+#[cfg(doc)]
+use crate::rlfmi::RLFMIndex;
 
-/// A search index that can be searched.
-pub trait BackwardSearchIndex: BackwardIterableIndex {
+/// A search index.
+///
+/// Using this trait, you can use [`FMIndex`] and [`RLFMIndex`]
+/// interchangeably.
+pub trait SearchIndex: BackwardIterableIndex {
     /// Search for a pattern in the text.
     ///
     /// Return a [`Search`] object with information about the search
     /// result.
-    fn search_backward<K>(&self, pattern: K) -> Search<Self>
+    fn search<K>(&self, pattern: K) -> Search<Self>
     where
         K: AsRef<[Self::T]>,
     {
@@ -18,7 +25,7 @@ pub trait BackwardSearchIndex: BackwardIterableIndex {
     }
 }
 
-impl<I: BackwardIterableIndex> BackwardSearchIndex for I {}
+impl<I: BackwardIterableIndex> SearchIndex for I {}
 
 /// An object containing the result of a search.
 ///
@@ -26,7 +33,7 @@ impl<I: BackwardIterableIndex> BackwardSearchIndex for I {}
 /// supplied with a sampled suffix array.
 pub struct Search<'a, I>
 where
-    I: BackwardSearchIndex,
+    I: SearchIndex,
 {
     index: &'a I,
     s: u64,
@@ -36,7 +43,7 @@ where
 
 impl<'a, I> Search<'a, I>
 where
-    I: BackwardSearchIndex,
+    I: SearchIndex,
 {
     fn new(index: &'a I) -> Search<'a, I> {
         Search {
@@ -101,7 +108,7 @@ where
 
 impl<I> Search<'_, I>
 where
-    I: BackwardSearchIndex + ForwardIterableIndex,
+    I: SearchIndex + ForwardIterableIndex,
 {
     /// Get an iterator that goes forwards through the text, producing
     /// [`Character`].
@@ -117,7 +124,7 @@ where
 
 impl<I> Search<'_, I>
 where
-    I: BackwardSearchIndex + Locatable,
+    I: SearchIndex + Locatable,
 {
     /// List the position of all occurrences.
     pub fn locate(&self) -> Vec<u64> {

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,6 @@
 use crate::iter::{BackwardIterableIndex, BackwardIterator, ForwardIterableIndex, ForwardIterator};
-use crate::suffix_array::{private, Locatable};
+use crate::seal;
+use crate::suffix_array::Locatable;
 
 #[cfg(doc)]
 use crate::character::Character;
@@ -130,7 +131,7 @@ where
     pub fn locate(&self) -> Vec<u64> {
         let mut results: Vec<u64> = Vec::with_capacity((self.e - self.s) as usize);
         for k in self.s..self.e {
-            results.push(self.index.get_sa::<private::Local>(k));
+            results.push(self.index.get_sa::<seal::Local>(k));
         }
         results
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,5 @@
 use crate::iter::{BackwardIterableIndex, BackwardIterator, ForwardIterableIndex, ForwardIterator};
-use crate::suffix_array::Locatable;
+use crate::suffix_array::{private, Locatable};
 
 #[cfg(doc)]
 use crate::character::Character;
@@ -123,7 +123,7 @@ where
     pub fn locate(&self) -> Vec<u64> {
         let mut results: Vec<u64> = Vec::with_capacity((self.e - self.s) as usize);
         for k in self.s..self.e {
-            results.push(self.index.get_sa(k));
+            results.push(self.index.get_sa::<private::Local>(k));
         }
         results
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,5 +1,5 @@
 use crate::iter::{BackwardIterableIndex, BackwardIterator, ForwardIterableIndex, ForwardIterator};
-use crate::suffix_array::IndexWithSA;
+use crate::suffix_array::Locatable;
 
 #[cfg(doc)]
 use crate::character::Character;
@@ -117,7 +117,7 @@ where
 
 impl<I> Search<'_, I>
 where
-    I: BackwardSearchIndex + IndexWithSA,
+    I: BackwardSearchIndex + Locatable,
 {
     /// List the position of all occurrences.
     pub fn locate(&self) -> Vec<u64> {

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -1,31 +1,18 @@
 //! Suffix arrays, used to construct the index.
 //!
 //! Can also be used in sampled fashion to perform locate queries.
-use crate::util;
+use crate::{seal, util};
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
 use vers_vecs::BitVec;
-
-pub(crate) mod private {
-    // https://jack.wrenn.fyi/blog/private-trait-methods/
-
-    // An effectively private type to encode locality. We make it uninhabited
-    // so we *cannot* accidentally leak it.
-    pub enum Local {}
-
-    // We pair it with a 'sealed' trait that is *only* implemented for `Local`.
-    pub trait IsLocal {}
-
-    impl IsLocal for Local {}
-}
 
 /// A trait for an index that supports locate queries.
 ///
 /// This is only supported when [`SuffixOrderSampledArray`] is passed in.
 pub trait Locatable {
     #[doc(hidden)]
-    fn get_sa<L: private::IsLocal>(&self, i: u64) -> u64;
+    fn get_sa<L: seal::IsLocal>(&self, i: u64) -> u64;
 }
 
 /// A sampled suffix array, stored within the index.

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -76,8 +76,9 @@ impl fmt::Debug for SuffixOrderSampledArray {
 ///
 /// A sampler will _sieve_ a suffix array for this purpose.
 pub trait ArraySampler<S> {
+    #[doc(hidden)]
     /// Given a suffix array, sample it and create a sampled array.
-    fn sample(&self, sa: Vec<u64>) -> S;
+    fn sample<L: private::IsLocal>(&self, sa: Vec<u64>) -> S;
 }
 
 /// The `NullSampler` does not store any sampled information.
@@ -95,7 +96,7 @@ impl NullSampler {
 }
 
 impl ArraySampler<()> for NullSampler {
-    fn sample(&self, _sa: Vec<u64>) {}
+    fn sample<L: private::IsLocal>(&self, _sa: Vec<u64>) {}
 }
 
 /// A sampler that sieves the suffix array for information to retain.
@@ -132,7 +133,7 @@ impl SuffixOrderSampler {
 }
 
 impl ArraySampler<SuffixOrderSampledArray> for SuffixOrderSampler {
-    fn sample(&self, sa: Vec<u64>) -> SuffixOrderSampledArray {
+    fn sample<L: private::IsLocal>(&self, sa: Vec<u64>) -> SuffixOrderSampledArray {
         let n = sa.len();
         let word_size = (util::log2(n as u64) + 1) as usize;
         debug_assert!(n > 0);
@@ -175,7 +176,9 @@ mod tests {
         ];
         for &(level, n) in cases.iter() {
             let sa = (0..n).collect::<Vec<u64>>();
-            let ssa = SuffixOrderSampler::new().level(level).sample(sa);
+            let ssa = SuffixOrderSampler::new()
+                .level(level)
+                .sample::<private::Local>(sa);
             for i in 0..n {
                 let v = ssa.get(i);
                 if i & ((1 << level) - 1) == 0 {

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -10,7 +10,7 @@ use vers_vecs::BitVec;
 /// A trait for an index that supports locate queries.
 ///
 /// This is only supported when [`SuffixOrderSampledArray`] is passed in.
-pub trait Locatable {
+pub trait HasPosition {
     #[doc(hidden)]
     fn get_sa<L: seal::IsLocal>(&self, i: u64) -> u64;
 }

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -158,6 +158,30 @@ impl ArraySampler<SuffixOrderSampledArray> for SuffixOrderSampler {
     }
 }
 
+pub(crate) fn sample(sa: Vec<u64>, level: usize) -> SuffixOrderSampledArray {
+    let n = sa.len();
+    let word_size = (util::log2(n as u64) + 1) as usize;
+    debug_assert!(n > 0);
+    debug_assert!(
+        n > (1 << level),
+        "sampling level L must satisfy 2^L < text_len (L = {}, text_len = {})",
+        level,
+        n,
+    );
+    let sa_samples_len = ((n - 1) >> level) + 1;
+    let mut sa_samples = BitVec::with_capacity(sa_samples_len);
+    // fid::BitArray::with_word_size(word_size, sa_samples_len);
+    for i in 0..sa_samples_len {
+        sa_samples.append_bits(sa[i << level], word_size);
+    }
+    SuffixOrderSampledArray {
+        level,
+        word_size,
+        sa: sa_samples,
+        len: sa.len(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -69,95 +69,6 @@ impl fmt::Debug for SuffixOrderSampledArray {
     }
 }
 
-/// In order to perform locate queries, we need to retain the suffix array that
-/// is generated during the construction phase. But we do not need the whole
-/// array as we can interpolate missing elements in a suffix array from other
-/// elements.
-///
-/// A sampler will _sieve_ a suffix array for this purpose.
-pub trait ArraySampler<S> {
-    #[doc(hidden)]
-    /// Given a suffix array, sample it and create a sampled array.
-    fn sample<L: private::IsLocal>(&self, sa: Vec<u64>) -> S;
-}
-
-/// The `NullSampler` does not store any sampled information.
-///
-/// If you do not need `locate` queries you can use this sampler.
-/// You won't have access to `locate` on the type level.
-#[derive(Default)]
-pub struct NullSampler {}
-
-impl NullSampler {
-    /// Construct a new null sampler.
-    pub fn new() -> Self {
-        NullSampler {}
-    }
-}
-
-impl ArraySampler<()> for NullSampler {
-    fn sample<L: private::IsLocal>(&self, _sa: Vec<u64>) {}
-}
-
-/// A sampler that sieves the suffix array for information to retain.
-///
-/// Use this if you want to perform `locate` queries.
-#[derive(Default)]
-pub struct SuffixOrderSampler {
-    level: usize,
-}
-
-impl SuffixOrderSampler {
-    /// Construct a new suffix order sampler.
-    ///
-    /// Defaults to level 0, meaning the information in the suffix array
-    /// is completely retained, with `O(N)` space complexity where `N`
-    /// is the size of the text.
-    pub fn new() -> Self {
-        SuffixOrderSampler { level: 0 }
-    }
-
-    /// Set the sampling level.
-    ///
-    /// The sampling level can be used to reduce the amount of information
-    /// retained at the cost of run-time performance.
-    ///
-    /// The sampling level `L` affects the space complexity of the sampled
-    /// array as `O(N / 2^L)` where `N` is the size of the text.
-    ///
-    /// The sampling level `L` must satisfy `2^L < N`.
-    pub fn level(mut self, level: usize) -> Self {
-        self.level = level;
-        self
-    }
-}
-
-impl ArraySampler<SuffixOrderSampledArray> for SuffixOrderSampler {
-    fn sample<L: private::IsLocal>(&self, sa: Vec<u64>) -> SuffixOrderSampledArray {
-        let n = sa.len();
-        let word_size = (util::log2(n as u64) + 1) as usize;
-        debug_assert!(n > 0);
-        debug_assert!(
-            n > (1 << self.level),
-            "sampling level L must satisfy 2^L < text_len (L = {}, text_len = {})",
-            self.level,
-            n,
-        );
-        let sa_samples_len = ((n - 1) >> self.level) + 1;
-        let mut sa_samples = BitVec::with_capacity(sa_samples_len);
-        // fid::BitArray::with_word_size(word_size, sa_samples_len);
-        for i in 0..sa_samples_len {
-            sa_samples.append_bits(sa[i << self.level], word_size);
-        }
-        SuffixOrderSampledArray {
-            level: self.level,
-            word_size,
-            sa: sa_samples,
-            len: sa.len(),
-        }
-    }
-}
-
 pub(crate) fn sample(sa: Vec<u64>, level: usize) -> SuffixOrderSampledArray {
     let n = sa.len();
     let word_size = (util::log2(n as u64) + 1) as usize;
@@ -200,9 +111,7 @@ mod tests {
         ];
         for &(level, n) in cases.iter() {
             let sa = (0..n).collect::<Vec<u64>>();
-            let ssa = SuffixOrderSampler::new()
-                .level(level)
-                .sample::<private::Local>(sa);
+            let ssa = sample(sa, level);
             for i in 0..n {
                 let v = ssa.get(i);
                 if i & ((1 << level) - 1) == 0 {

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -11,10 +11,10 @@ pub trait IndexWithSA {
     fn get_sa(&self, i: u64) -> u64;
 }
 
-pub(crate) trait PartialArray {
-    fn get(&self, i: u64) -> Option<u64>;
-    fn size(&self) -> usize;
-}
+// pub(crate) trait PartialArray {
+//     fn get(&self, i: u64) -> Option<u64>;
+//     fn size(&self) -> usize;
+// }
 
 /// A sampled suffix array, stored within the index.
 #[derive(Serialize, Deserialize)]
@@ -25,8 +25,8 @@ pub struct SuffixOrderSampledArray {
     len: usize,
 }
 
-impl PartialArray for SuffixOrderSampledArray {
-    fn get(&self, i: u64) -> Option<u64> {
+impl SuffixOrderSampledArray {
+    pub(crate) fn get(&self, i: u64) -> Option<u64> {
         debug_assert!(i < self.len as u64);
         if i & ((1 << self.level) - 1) == 0 {
             Some(
@@ -40,7 +40,7 @@ impl PartialArray for SuffixOrderSampledArray {
         }
     }
 
-    fn size(&self) -> usize {
+    pub(crate) fn size(&self) -> usize {
         std::mem::size_of::<Self>() + self.sa.heap_size()
     }
 }

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -7,14 +7,26 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 use vers_vecs::BitVec;
 
-pub trait Locatable {
-    fn get_sa(&self, i: u64) -> u64;
+pub(crate) mod private {
+    // https://jack.wrenn.fyi/blog/private-trait-methods/
+
+    // An effectively private type to encode locality. We make it uninhabited
+    // so we *cannot* accidentally leak it.
+    pub enum Local {}
+
+    // We pair it with a 'sealed' trait that is *only* implemented for `Local`.
+    pub trait IsLocal {}
+
+    impl IsLocal for Local {}
 }
 
-// pub(crate) trait PartialArray {
-//     fn get(&self, i: u64) -> Option<u64>;
-//     fn size(&self) -> usize;
-// }
+/// A trait for an index that supports locate queries.
+///
+/// This is only supported when [`SuffixOrderSampledArray`] is passed in.
+pub trait Locatable {
+    #[doc(hidden)]
+    fn get_sa<L: private::IsLocal>(&self, i: u64) -> u64;
+}
 
 /// A sampled suffix array, stored within the index.
 #[derive(Serialize, Deserialize)]

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 use vers_vecs::BitVec;
 
-pub trait IndexWithSA {
+pub trait Locatable {
     fn get_sa(&self, i: u64) -> u64;
 }
 

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -69,7 +69,7 @@ impl fmt::Debug for SuffixOrderSampledArray {
     }
 }
 
-pub(crate) fn sample(sa: Vec<u64>, level: usize) -> SuffixOrderSampledArray {
+pub(crate) fn sample(sa: &[u64], level: usize) -> SuffixOrderSampledArray {
     let n = sa.len();
     let word_size = (util::log2(n as u64) + 1) as usize;
     debug_assert!(n > 0);
@@ -111,7 +111,7 @@ mod tests {
         ];
         for &(level, n) in cases.iter() {
             let sa = (0..n).collect::<Vec<u64>>();
-            let ssa = sample(sa, level);
+            let ssa = sample(&sa, level);
             for i in 0..n {
                 let v = ssa.get(i);
                 if i & ((1 << level) - 1) == 0 {


### PR DESCRIPTION
Hide as much as possible from the public API.

This PR is based on #29 and #31 which should be reviewed and merged first.

- `search_backward` renamed to `search` as it's the only kind of search possible
- `SearchIndex` and `Locatable` are the primary indexes on the FMIndex and RLFMIndex. 
- `search` method can be used on index without having to import the `SearchIndex` trait
- sealed away methods that shouldn't be implementable from the outside. It's ugly but it shouldn't have performance impact and I couldn't find a better way to do it without a huge restructuring.
- got rid of traits in `suffix_array` in favor of smarter constructor methods.

The documentation now builds without any "missing docs" warnings.

We could probably hide both ForwardIterator and BackwardIterator from the public API if we wanted to, not sure. Right now they're visible and I've exported them as they're used.
