### PR TITLE
Merge backwards forwards

### DIFF
--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -153,21 +153,21 @@ where
 {
     type T = T;
 
-    fn get_l<L: seal::IsLocal>(&self, i: u64) -> Self::T {
+    fn get_l_backward<L: seal::IsLocal>(&self, i: u64) -> Self::T {
         Self::T::from_u64(self.bw.get_u64_unchecked(i as usize))
     }
 
-    fn lf_map<L: seal::IsLocal>(&self, i: u64) -> u64 {
-        let c = self.get_l::<L>(i);
+    fn lf_map_backward<L: seal::IsLocal>(&self, i: u64) -> u64 {
+        let c = self.get_l_backward::<L>(i);
         self.cs[c.into() as usize] + self.bw.rank_u64_unchecked(i as usize, c.into()) as u64
     }
 
-    fn lf_map2<L: seal::IsLocal>(&self, c: T, i: u64) -> u64 {
+    fn lf_map2_backward<L: seal::IsLocal>(&self, c: T, i: u64) -> u64 {
         let c = self.converter.convert(c);
         self.cs[c.into() as usize] + self.bw.rank_u64_unchecked(i as usize, c.into()) as u64
     }
 
-    fn len<L: seal::IsLocal>(&self) -> u64 {
+    fn len_backward<L: seal::IsLocal>(&self) -> u64 {
         self.bw.len() as u64
     }
 }
@@ -178,7 +178,7 @@ where
     C: Converter<T>,
 {
     type T = T;
-    fn get_f<L: seal::IsLocal>(&self, i: u64) -> Self::T {
+    fn get_f_forward<L: seal::IsLocal>(&self, i: u64) -> Self::T {
         // binary search to find c s.t. cs[c] <= i < cs[c+1]
         // <=> c is the greatest index s.t. cs[c] <= i
         // invariant: c exists in [s, e)
@@ -195,14 +195,14 @@ where
         T::from_u64(s as u64)
     }
 
-    fn fl_map<L: seal::IsLocal>(&self, i: u64) -> u64 {
-        let c = self.get_f::<L>(i);
+    fn fl_map_forward<L: seal::IsLocal>(&self, i: u64) -> u64 {
+        let c = self.get_f_forward::<L>(i);
         self.bw
             .select_u64_unchecked(i as usize - self.cs[c.into() as usize] as usize, c.into())
             as u64
     }
 
-    fn fl_map2<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64 {
+    fn fl_map2_forward<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64 {
         let c = self.converter.convert(c);
         self.bw
             .select_u64_unchecked((i - self.cs[c.into() as usize]) as usize, c.into())
@@ -227,7 +227,7 @@ where
                     return (sa + steps) % self.bw.len() as u64;
                 }
                 None => {
-                    i = self.lf_map::<seal::Local>(i);
+                    i = self.lf_map_backward::<seal::Local>(i);
                     steps += 1;
                 }
             }
@@ -331,7 +331,7 @@ mod tests {
         let fm_index = FMIndex::new(text, RangeConverter::new(b'a', b'z'), 2);
         let mut i = 0;
         for a in ans {
-            i = fm_index.lf_map::<seal::Local>(i);
+            i = fm_index.lf_map_backward::<seal::Local>(i);
             assert_eq!(i, a);
         }
     }
@@ -342,7 +342,7 @@ mod tests {
         let fm_index = FMIndex::new(text, RangeConverter::new(b'a', b'z'), 2);
         let cases = vec![5u64, 0, 7, 10, 11, 4, 1, 6, 2, 3, 8, 9];
         for (i, expected) in cases.into_iter().enumerate() {
-            let actual = fm_index.fl_map::<seal::Local>(i as u64);
+            let actual = fm_index.fl_map_forward::<seal::Local>(i as u64);
             assert_eq!(actual, expected);
         }
     }

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -4,9 +4,9 @@ use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::search::SearchIndex;
 use crate::suffix_array::{self, HasPosition, SuffixOrderSampledArray};
+use crate::IterableIndex;
 use crate::{sais, seal};
 use crate::{util, Search};
-use crate::{BackwardIterableIndex, ForwardIterableIndex};
 
 use serde::{Deserialize, Serialize};
 use vers_vecs::WaveletMatrix;
@@ -146,7 +146,7 @@ impl<T, C> FMIndex<T, C, SuffixOrderSampledArray> {
     }
 }
 
-impl<T, C, S> BackwardIterableIndex for FMIndex<T, C, S>
+impl<T, C, S> IterableIndex for FMIndex<T, C, S>
 where
     T: Character,
     C: Converter<T>,
@@ -167,17 +167,6 @@ where
         self.cs[c.into() as usize] + self.bw.rank_u64_unchecked(i as usize, c.into()) as u64
     }
 
-    fn len_backward<L: seal::IsLocal>(&self) -> u64 {
-        self.bw.len() as u64
-    }
-}
-
-impl<T, C, S> ForwardIterableIndex for FMIndex<T, C, S>
-where
-    T: Character,
-    C: Converter<T>,
-{
-    type T = T;
     fn get_f_forward<L: seal::IsLocal>(&self, i: u64) -> Self::T {
         // binary search to find c s.t. cs[c] <= i < cs[c+1]
         // <=> c is the greatest index s.t. cs[c] <= i

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -3,10 +3,13 @@ use crate::converter::{Converter, IndexWithConverter};
 use crate::character::Character;
 use crate::seal;
 
-/// A search index that can be searched backwards.
-pub trait BackwardIterableIndex: Sized {
+/// An index that can be iterated through.
+pub trait IterableIndex: Sized {
     /// A [`Character`] type.
     type T: Character;
+
+    #[doc(hidden)]
+    fn len<L: seal::IsLocal>(&self) -> u64;
 
     #[doc(hidden)]
     fn get_l_backward<L: seal::IsLocal>(&self, i: u64) -> Self::T;
@@ -14,42 +17,12 @@ pub trait BackwardIterableIndex: Sized {
     fn lf_map_backward<L: seal::IsLocal>(&self, i: u64) -> u64;
     #[doc(hidden)]
     fn lf_map2_backward<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64;
-    #[doc(hidden)]
-    fn len_backward<L: seal::IsLocal>(&self) -> u64;
 
     #[doc(hidden)]
     fn iter_backward<L: seal::IsLocal>(&self, i: u64) -> BackwardIterator<Self> {
-        debug_assert!(i < self.len_backward::<seal::Local>());
+        debug_assert!(i < self.len::<seal::Local>());
         BackwardIterator { index: self, i }
     }
-}
-
-/// An iterator that goes backwards through the text, producing [`Character`].
-pub struct BackwardIterator<'a, I>
-where
-    I: BackwardIterableIndex,
-{
-    index: &'a I,
-    i: u64,
-}
-
-impl<T, I> Iterator for BackwardIterator<'_, I>
-where
-    T: Character,
-    I: BackwardIterableIndex<T = T> + IndexWithConverter<T>,
-{
-    type Item = <I as BackwardIterableIndex>::T;
-    fn next(&mut self) -> Option<Self::Item> {
-        let c = self.index.get_l_backward::<seal::Local>(self.i);
-        self.i = self.index.lf_map_backward::<seal::Local>(self.i);
-        Some(self.index.get_converter().convert_inv(c))
-    }
-}
-
-/// A search index that can be searched forwards.
-pub trait ForwardIterableIndex: Sized {
-    /// A [`Character`] type.
-    type T: Character;
 
     #[doc(hidden)]
     fn get_f_forward<L: seal::IsLocal>(&self, i: u64) -> Self::T;
@@ -57,8 +30,6 @@ pub trait ForwardIterableIndex: Sized {
     fn fl_map_forward<L: seal::IsLocal>(&self, i: u64) -> u64;
     #[doc(hidden)]
     fn fl_map2_forward<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64;
-    #[doc(hidden)]
-    fn len<L: seal::IsLocal>(&self) -> u64;
 
     #[doc(hidden)]
     fn iter_forward<L: seal::IsLocal>(&self, i: u64) -> ForwardIterator<Self> {
@@ -67,10 +38,32 @@ pub trait ForwardIterableIndex: Sized {
     }
 }
 
+/// An iterator that goes backwards through the text, producing [`Character`].
+pub struct BackwardIterator<'a, I>
+where
+    I: IterableIndex,
+{
+    index: &'a I,
+    i: u64,
+}
+
+impl<T, I> Iterator for BackwardIterator<'_, I>
+where
+    T: Character,
+    I: IterableIndex<T = T> + IndexWithConverter<T>,
+{
+    type Item = <I as IterableIndex>::T;
+    fn next(&mut self) -> Option<Self::Item> {
+        let c = self.index.get_l_backward::<seal::Local>(self.i);
+        self.i = self.index.lf_map_backward::<seal::Local>(self.i);
+        Some(self.index.get_converter().convert_inv(c))
+    }
+}
+
 /// An iterator that goes forwards through the text, producing [`Character`].
 pub struct ForwardIterator<'a, I>
 where
-    I: ForwardIterableIndex,
+    I: IterableIndex,
 {
     index: &'a I,
     i: u64,
@@ -79,9 +72,9 @@ where
 impl<T, I> Iterator for ForwardIterator<'_, I>
 where
     T: Character,
-    I: ForwardIterableIndex<T = T> + IndexWithConverter<T>,
+    I: IterableIndex<T = T> + IndexWithConverter<T>,
 {
-    type Item = <I as ForwardIterableIndex>::T;
+    type Item = <I as IterableIndex>::T;
     fn next(&mut self) -> Option<Self::Item> {
         let c = self.index.get_f_forward::<seal::Local>(self.i);
         self.i = self.index.fl_map_forward::<seal::Local>(self.i);

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -9,17 +9,17 @@ pub trait BackwardIterableIndex: Sized {
     type T: Character;
 
     #[doc(hidden)]
-    fn get_l<L: seal::IsLocal>(&self, i: u64) -> Self::T;
+    fn get_l_backward<L: seal::IsLocal>(&self, i: u64) -> Self::T;
     #[doc(hidden)]
-    fn lf_map<L: seal::IsLocal>(&self, i: u64) -> u64;
+    fn lf_map_backward<L: seal::IsLocal>(&self, i: u64) -> u64;
     #[doc(hidden)]
-    fn lf_map2<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64;
+    fn lf_map2_backward<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64;
     #[doc(hidden)]
-    fn len<L: seal::IsLocal>(&self) -> u64;
+    fn len_backward<L: seal::IsLocal>(&self) -> u64;
 
     #[doc(hidden)]
     fn iter_backward<L: seal::IsLocal>(&self, i: u64) -> BackwardIterator<Self> {
-        debug_assert!(i < self.len::<seal::Local>());
+        debug_assert!(i < self.len_backward::<seal::Local>());
         BackwardIterator { index: self, i }
     }
 }
@@ -40,8 +40,8 @@ where
 {
     type Item = <I as BackwardIterableIndex>::T;
     fn next(&mut self) -> Option<Self::Item> {
-        let c = self.index.get_l::<seal::Local>(self.i);
-        self.i = self.index.lf_map::<seal::Local>(self.i);
+        let c = self.index.get_l_backward::<seal::Local>(self.i);
+        self.i = self.index.lf_map_backward::<seal::Local>(self.i);
         Some(self.index.get_converter().convert_inv(c))
     }
 }
@@ -52,11 +52,11 @@ pub trait ForwardIterableIndex: Sized {
     type T: Character;
 
     #[doc(hidden)]
-    fn get_f<L: seal::IsLocal>(&self, i: u64) -> Self::T;
+    fn get_f_forward<L: seal::IsLocal>(&self, i: u64) -> Self::T;
     #[doc(hidden)]
-    fn fl_map<L: seal::IsLocal>(&self, i: u64) -> u64;
+    fn fl_map_forward<L: seal::IsLocal>(&self, i: u64) -> u64;
     #[doc(hidden)]
-    fn fl_map2<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64;
+    fn fl_map2_forward<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64;
     #[doc(hidden)]
     fn len<L: seal::IsLocal>(&self) -> u64;
 
@@ -83,8 +83,8 @@ where
 {
     type Item = <I as ForwardIterableIndex>::T;
     fn next(&mut self) -> Option<Self::Item> {
-        let c = self.index.get_f::<seal::Local>(self.i);
-        self.i = self.index.fl_map::<seal::Local>(self.i);
+        let c = self.index.get_f_forward::<seal::Local>(self.i);
+        self.i = self.index.fl_map_forward::<seal::Local>(self.i);
         Some(self.index.get_converter().convert_inv(c))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,5 +151,5 @@ pub use crate::fm_index::FMIndex;
 pub use crate::rlfmi::RLFMIndex;
 
 pub use character::Character;
-pub use iter::{BackwardIterableIndex, BackwardIterator, ForwardIterableIndex, ForwardIterator};
+pub use iter::{BackwardIterator, ForwardIterator, IterableIndex};
 pub use search::{Search, SearchIndex};

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -4,9 +4,8 @@ use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::search::SearchIndex;
 use crate::suffix_array::{self, HasPosition, SuffixOrderSampledArray};
-use crate::{sais, Search};
+use crate::{sais, IterableIndex, Search};
 use crate::{seal, util};
-use crate::{BackwardIterableIndex, ForwardIterableIndex};
 
 use serde::{Deserialize, Serialize};
 use vers_vecs::{BitVec, RsVec, WaveletMatrix};
@@ -203,16 +202,12 @@ where
     }
 }
 
-impl<T, C, S> BackwardIterableIndex for RLFMIndex<T, C, S>
+impl<T, C, S> IterableIndex for RLFMIndex<T, C, S>
 where
     T: Character,
     C: Converter<T>,
 {
     type T = T;
-
-    fn len_backward<L: seal::IsLocal>(&self) -> u64 {
-        self.len
-    }
 
     fn get_l_backward<L: seal::IsLocal>(&self, i: u64) -> T {
         // note: b[0] is always 1
@@ -238,14 +233,6 @@ where
                 - self.b.select1(j) as u64
         }
     }
-}
-
-impl<T, C, S> ForwardIterableIndex for RLFMIndex<T, C, S>
-where
-    T: Character,
-    C: Converter<T>,
-{
-    type T = T;
 
     fn get_f_forward<L: seal::IsLocal>(&self, i: u64) -> Self::T {
         let mut s = 0;

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -210,28 +210,28 @@ where
 {
     type T = T;
 
-    fn len<L: seal::IsLocal>(&self) -> u64 {
+    fn len_backward<L: seal::IsLocal>(&self) -> u64 {
         self.len
     }
 
-    fn get_l<L: seal::IsLocal>(&self, i: u64) -> T {
+    fn get_l_backward<L: seal::IsLocal>(&self, i: u64) -> T {
         // note: b[0] is always 1
         T::from_u64(self.s.get_u64_unchecked(self.b.rank1(i as usize + 1) - 1))
     }
 
-    fn lf_map<L: seal::IsLocal>(&self, i: u64) -> u64 {
-        let c = self.get_l::<L>(i);
+    fn lf_map_backward<L: seal::IsLocal>(&self, i: u64) -> u64 {
+        let c = self.get_l_backward::<L>(i);
         let j = self.b.rank1(i as usize);
         let nr = self.s.rank_u64_unchecked(j, c.into());
         self.bp.select1(self.cs[c.into() as usize] as usize + nr) as u64 + i
             - self.b.select1(j) as u64
     }
 
-    fn lf_map2<L: seal::IsLocal>(&self, c: T, i: u64) -> u64 {
+    fn lf_map2_backward<L: seal::IsLocal>(&self, c: T, i: u64) -> u64 {
         let c = self.converter.convert(c);
         let j = self.b.rank1(i as usize);
         let nr = self.s.rank_u64_unchecked(j, c.into());
-        if self.get_l::<L>(i) != c {
+        if self.get_l_backward::<L>(i) != c {
             self.bp.select1(self.cs[c.into() as usize] as usize + nr) as u64
         } else {
             self.bp.select1(self.cs[c.into() as usize] as usize + nr) as u64 + i
@@ -247,7 +247,7 @@ where
 {
     type T = T;
 
-    fn get_f<L: seal::IsLocal>(&self, i: u64) -> Self::T {
+    fn get_f_forward<L: seal::IsLocal>(&self, i: u64) -> Self::T {
         let mut s = 0;
         let mut e = self.cs.len();
         let r = (self.bp.rank1(i as usize + 1) - 1) as u64;
@@ -262,8 +262,8 @@ where
         T::from_u64(s as u64)
     }
 
-    fn fl_map<L: seal::IsLocal>(&self, i: u64) -> u64 {
-        let c = self.get_f::<L>(i);
+    fn fl_map_forward<L: seal::IsLocal>(&self, i: u64) -> u64 {
+        let c = self.get_f_forward::<L>(i);
         let j = self.bp.rank1(i as usize + 1) - 1;
         let p = self.bp.select1(j) as u64;
         let m = self
@@ -273,7 +273,7 @@ where
         n + i - p
     }
 
-    fn fl_map2<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64 {
+    fn fl_map2_forward<L: seal::IsLocal>(&self, c: Self::T, i: u64) -> u64 {
         let c = self.converter.convert(c);
         let j = self.bp.rank1(i as usize + 1) - 1;
         let p = self.bp.select1(j) as u64;
@@ -302,7 +302,7 @@ where
                     return (sa + steps) % self.len();
                 }
                 None => {
-                    i = self.lf_map::<seal::Local>(i);
+                    i = self.lf_map_backward::<seal::Local>(i);
                     steps += 1;
                 }
             }
@@ -458,7 +458,7 @@ mod tests {
         let ans = "ipssm\0pissii".to_string().into_bytes();
 
         for (i, a) in ans.into_iter().enumerate() {
-            let l = rlfmi.get_l::<seal::Local>(i as u64);
+            let l = rlfmi.get_l_backward::<seal::Local>(i as u64);
             assert_eq!(rlfmi.converter.convert_inv(l), a);
         }
     }
@@ -471,7 +471,7 @@ mod tests {
 
         let mut i = 0;
         for a in ans {
-            let next_i = rlfmi.lf_map::<seal::Local>(i);
+            let next_i = rlfmi.lf_map_backward::<seal::Local>(i);
             assert_eq!(next_i, a, "should be lf_map({}) == {}", i, a);
             i = next_i;
         }
@@ -491,8 +491,8 @@ mod tests {
         let n = rlfmi.len();
 
         for (c, r) in ans {
-            let s = rlfmi.lf_map2::<seal::Local>(c, 0);
-            let e = rlfmi.lf_map2::<seal::Local>(c, n);
+            let s = rlfmi.lf_map2_backward::<seal::Local>(c, 0);
+            let e = rlfmi.lf_map2_backward::<seal::Local>(c, n);
             assert_eq!(
                 (s, e),
                 r,
@@ -549,7 +549,7 @@ mod tests {
         let rlfmi = RLFMIndex::count_only(text, RangeConverter::new(b'a', b'z'));
 
         for (i, a) in ans.into_iter().enumerate() {
-            let f = rlfmi.get_f::<seal::Local>(i as u64);
+            let f = rlfmi.get_f_forward::<seal::Local>(i as u64);
             assert_eq!(rlfmi.converter.convert_inv(f), a);
         }
     }
@@ -560,7 +560,7 @@ mod tests {
         let rlfmi = RLFMIndex::count_only(text, RangeConverter::new(b'a', b'z'));
         let cases = vec![5u64, 0, 7, 10, 11, 4, 1, 6, 2, 3, 8, 9];
         for (i, expected) in cases.into_iter().enumerate() {
-            let actual = rlfmi.fl_map::<seal::Local>(i as u64);
+            let actual = rlfmi.fl_map_forward::<seal::Local>(i as u64);
             assert_eq!(actual, expected);
         }
     }

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,4 +1,4 @@
-use crate::iter::{BackwardIterableIndex, BackwardIterator, ForwardIterableIndex, ForwardIterator};
+use crate::iter::{BackwardIterator, ForwardIterator, IterableIndex};
 use crate::seal;
 use crate::suffix_array::HasPosition;
 
@@ -13,7 +13,7 @@ use crate::rlfmi::RLFMIndex;
 ///
 /// Using this trait, you can use [`FMIndex`] and [`RLFMIndex`]
 /// interchangeably using generics.
-pub trait SearchIndex: BackwardIterableIndex {
+pub trait SearchIndex: IterableIndex {
     /// Search for a pattern in the text.
     ///
     /// Return a [`Search`] object with information about the search
@@ -26,7 +26,7 @@ pub trait SearchIndex: BackwardIterableIndex {
     }
 }
 
-impl<I: BackwardIterableIndex> SearchIndex for I {}
+impl<I: IterableIndex> SearchIndex for I {}
 
 /// An object containing the result of a search.
 ///
@@ -50,7 +50,7 @@ where
         Search {
             index,
             s: 0,
-            e: index.len_backward::<seal::Local>(),
+            e: index.len::<seal::Local>(),
             pattern: vec![],
         }
     }
@@ -93,7 +93,7 @@ where
 
 impl<I> Search<'_, I>
 where
-    I: BackwardIterableIndex,
+    I: IterableIndex,
 {
     /// Get an iterator that goes backwards through the text, producing
     /// [`Character`].
@@ -109,7 +109,7 @@ where
 
 impl<I> Search<'_, I>
 where
-    I: SearchIndex + ForwardIterableIndex,
+    I: SearchIndex + IterableIndex,
 {
     /// Get an iterator that goes forwards through the text, producing
     /// [`Character`].

--- a/src/search.rs
+++ b/src/search.rs
@@ -50,7 +50,7 @@ where
         Search {
             index,
             s: 0,
-            e: index.len::<seal::Local>(),
+            e: index.len_backward::<seal::Local>(),
             pattern: vec![],
         }
     }
@@ -64,8 +64,8 @@ where
         let mut e = self.e;
         let mut pattern = pattern.as_ref().to_vec();
         for &c in pattern.iter().rev() {
-            s = self.index.lf_map2::<seal::Local>(c, s);
-            e = self.index.lf_map2::<seal::Local>(c, e);
+            s = self.index.lf_map2_backward::<seal::Local>(c, s);
+            e = self.index.lf_map2_backward::<seal::Local>(c, e);
             if s == e {
                 break;
             }


### PR DESCRIPTION
As part of the #30 I've merged the BackwardIterableIndex with the ForwardIterableIndex. This doesn't do anything yet to hide this trait from the public API, but it's in preparation of that.