### PR TITLE
Improve traits and document them

### DIFF
--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -4,7 +4,7 @@ use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::iter::FMIndexBackend;
 use crate::suffix_array::{self, HasPosition, SuffixOrderSampledArray};
-use crate::{sais, seal};
+use crate::{sais, seal, HeapSize};
 use crate::{util, Search};
 
 use serde::{Deserialize, Serialize};
@@ -95,7 +95,11 @@ where
     }
 }
 
-impl<T, C> FMIndex<T, C, ()> {
+impl<T, C> FMIndex<T, C, ()>
+where
+    T: Character,
+    C: Converter<T>,
+{
     /// The size on the heap of the FM-Index.
     ///
     /// No suffix array information is stored in this index.
@@ -106,7 +110,11 @@ impl<T, C> FMIndex<T, C, ()> {
     }
 }
 
-impl<T, C> FMIndex<T, C, SuffixOrderSampledArray> {
+impl<T, C> FMIndex<T, C, SuffixOrderSampledArray>
+where
+    T: Character,
+    C: Converter<T>,
+{
     /// The size on the heap of the FM-Index.
     ///
     /// Sampled suffix array data is stored in this index.
@@ -115,6 +123,26 @@ impl<T, C> FMIndex<T, C, SuffixOrderSampledArray> {
             + self.bw.heap_size()
             + self.cs.len() * std::mem::size_of::<Vec<u64>>()
             + self.suffix_array.size()
+    }
+}
+
+impl<T, C> HeapSize for FMIndex<T, C, SuffixOrderSampledArray>
+where
+    T: Character,
+    C: Converter<T>,
+{
+    fn size(&self) -> usize {
+        FMIndex::<T, C, SuffixOrderSampledArray>::size(self)
+    }
+}
+
+impl<T, C> HeapSize for FMIndex<T, C, ()>
+where
+    T: Character,
+    C: Converter<T>,
+{
+    fn size(&self) -> usize {
+        FMIndex::<T, C, ()>::size(self)
     }
 }
 
@@ -127,7 +155,7 @@ where
 {
     type T = T;
 
-    fn len<L: seal::IsLocal>(&self) -> u64 {
+    fn len(&self) -> u64 {
         self.bw.len() as u64
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,4 +153,4 @@ pub use crate::rlfmi::RLFMIndex;
 pub use builder::SearchIndexBuilder;
 pub use character::Character;
 pub use iter::{BackwardIterator, FMIndexBackend, ForwardIterator, HeapSize};
-pub use search::{Search, SearchIndex};
+pub use search::Search;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,5 +152,5 @@ pub use crate::rlfmi::RLFMIndex;
 
 pub use builder::SearchIndexBuilder;
 pub use character::Character;
-pub use iter::{BackwardIterator, FMIndexBackend, ForwardIterator};
+pub use iter::{BackwardIterator, FMIndexBackend, ForwardIterator, HeapSize};
 pub use search::{Search, SearchIndex};

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -4,7 +4,7 @@ use crate::converter;
 use crate::converter::{Converter, IndexWithConverter};
 use crate::iter::FMIndexBackend;
 use crate::suffix_array::{self, HasPosition, SuffixOrderSampledArray};
-use crate::{sais, Search};
+use crate::{sais, HeapSize, Search};
 use crate::{seal, util};
 
 use serde::{Deserialize, Serialize};
@@ -142,6 +142,7 @@ where
 impl<T, C> RLFMIndex<T, C, ()>
 where
     T: Character,
+    C: Converter<T>,
 {
     /// Heap size of the index.
     ///
@@ -158,6 +159,7 @@ where
 impl<T, C> RLFMIndex<T, C, SuffixOrderSampledArray>
 where
     T: Character,
+    C: Converter<T>,
 {
     /// The size on the heap of the FM-Index.
     ///
@@ -172,6 +174,26 @@ where
     }
 }
 
+impl<T, C> HeapSize for RLFMIndex<T, C, SuffixOrderSampledArray>
+where
+    T: Character,
+    C: Converter<T>,
+{
+    fn size(&self) -> usize {
+        RLFMIndex::<T, C, SuffixOrderSampledArray>::size(self)
+    }
+}
+
+impl<T, C> HeapSize for RLFMIndex<T, C, ()>
+where
+    T: Character,
+    C: Converter<T>,
+{
+    fn size(&self) -> usize {
+        RLFMIndex::<T, C, ()>::size(self)
+    }
+}
+
 impl<T, C, S> seal::Sealed for RLFMIndex<T, C, S> {}
 
 impl<T, C, S> FMIndexBackend for RLFMIndex<T, C, S>
@@ -181,7 +203,7 @@ where
 {
     type T = T;
 
-    fn len<L: seal::IsLocal>(&self) -> u64 {
+    fn len(&self) -> u64 {
         self.len
     }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -8,21 +8,6 @@ use crate::iter::FMIndexBackend;
 use crate::seal;
 use crate::suffix_array::HasPosition;
 
-/// A full-text index backed by FM-Index or its variant.
-pub struct SearchIndex<I: FMIndexBackend> {
-    index: I,
-}
-
-impl<I: FMIndexBackend> SearchIndex<I> {
-    /// Search for a pattern in the text.
-    ///
-    /// Return a [`Search`] object with information about the search
-    /// result.
-    pub fn search<K: AsRef<[I::T]>>(&self, pattern: K) -> Search<I> {
-        self.index.search(pattern)
-    }
-}
-
 /// An object containing the result of a search.
 ///
 /// This is expanded with a `locate` method if the index is

--- a/src/search.rs
+++ b/src/search.rs
@@ -42,7 +42,7 @@ where
         Search {
             index,
             s: 0,
-            e: index.len::<seal::Local>(),
+            e: index.len(),
             pattern: vec![],
         }
     }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1,0 +1,103 @@
+// tests that exercise the public API, especially the traits
+
+use fm_index::{FMIndexBackend, HeapSize};
+
+fn len<T: FMIndexBackend>(index: &T) -> u64 {
+    index.len()
+}
+
+fn size<T: HeapSize>(t: &T) -> usize {
+    t.size()
+}
+
+#[test]
+fn test_fm_index_backend_trait_fm_index_suffix_array() {
+    let builder = fm_index::SearchIndexBuilder::new();
+    let text = "text";
+
+    let index = builder.build(text.as_bytes().to_vec());
+
+    // any result will do for this test
+    assert_eq!(len(&index), 5);
+}
+
+#[test]
+fn test_heap_size_trait_fm_index_suffix_array() {
+    let builder = fm_index::SearchIndexBuilder::new();
+    let text = "text";
+
+    let index = builder.build(text.as_bytes().to_vec());
+
+    // any result will do for this test
+    assert!(size(&index) > 0);
+}
+
+#[test]
+fn test_fm_index_backend_trait_fm_index_count_only() {
+    let builder = fm_index::SearchIndexBuilder::new().count_only();
+    let text = "text";
+
+    let index = builder.build(text.as_bytes().to_vec());
+
+    // any result will do for this test
+    assert_eq!(len(&index), 5);
+}
+
+#[test]
+fn test_heap_size_trait_fm_index_count_only() {
+    let builder = fm_index::SearchIndexBuilder::new().count_only();
+    let text = "text";
+
+    let index = builder.build(text.as_bytes().to_vec());
+
+    // any result will do for this test
+    assert!(size(&index) > 0);
+}
+
+#[test]
+fn test_fm_index_backend_trait_rlfm_index_suffix_array() {
+    let builder = fm_index::SearchIndexBuilder::new().run_length_encoding();
+    let text = "text";
+
+    let index = builder.build(text.as_bytes().to_vec());
+
+    // any result will do for this test
+    assert_eq!(len(&index), 5);
+}
+
+#[test]
+fn test_heap_size_trait_rlfm_index_suffix_array() {
+    let builder = fm_index::SearchIndexBuilder::new().run_length_encoding();
+    let text = "text";
+
+    let index = builder.build(text.as_bytes().to_vec());
+
+    // any result will do for this test
+    assert!(size(&index) > 0);
+}
+
+#[test]
+fn test_fm_index_backend_trait_rlfm_index_count_only() {
+    let builder = fm_index::SearchIndexBuilder::new()
+        .count_only()
+        .run_length_encoding();
+    let text = "text";
+
+    let index = builder.build(text.as_bytes().to_vec());
+
+    // any result will do for this test
+    assert_eq!(len(&index), 5);
+}
+
+#[test]
+fn test_heap_size_trait_rlfm_index_count_only() {
+    let builder = fm_index::SearchIndexBuilder::new()
+        .count_only()
+        .run_length_encoding();
+    let text = "text";
+
+    let index = builder.build(text.as_bytes().to_vec());
+
+    // any result will do for this test
+    assert!(size(&index) > 0);
+}


### PR DESCRIPTION
I do the following:

* document the `search` method on the `FMIndexBackend` trait

* make the `len()` method public on the `FMIndexBackend` trait as I think it may be useful to end-users.

* Introduce a `HeapSize` trait so we can get the heap size of an index generically

* Introduce API tests that exercise the API through the traits, to make sure I got them right (it's easy to get into infinite recursion; only fixed once I refined the trait bounds for Character and Converter).

* Remove the `SearchIndex` struct in favor using the `FMIndexBackend` trait as discussed.