### PR TITLE
Introduce a SearchIndex trait and SearchIndexWithLocate trait.

### DIFF
--- a/benches/count.rs
+++ b/benches/count.rs
@@ -1,11 +1,11 @@
-use fm_index::{FMIndexBackend, SearchIndexBuilder};
+use fm_index::{SearchIndex, SearchIndexBuilder};
 
 use criterion::{criterion_group, criterion_main};
 use criterion::{AxisScale, BatchSize, BenchmarkId, Criterion, PlotConfiguration, Throughput};
 
 mod common;
 
-fn prepare_fmindex(len: usize, prob: f64, m: usize) -> (impl FMIndexBackend<T = u8>, Vec<String>) {
+fn prepare_fmindex(len: usize, prob: f64, m: usize) -> (impl SearchIndex<u8>, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (
@@ -16,11 +16,7 @@ fn prepare_fmindex(len: usize, prob: f64, m: usize) -> (impl FMIndexBackend<T = 
     )
 }
 
-fn prepare_rlfmindex(
-    len: usize,
-    prob: f64,
-    m: usize,
-) -> (impl FMIndexBackend<T = u8>, Vec<String>) {
+fn prepare_rlfmindex(len: usize, prob: f64, m: usize) -> (impl SearchIndex<u8>, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (
@@ -45,7 +41,7 @@ pub fn bench(c: &mut Criterion) {
                 || prepare_fmindex(n, prob, m),
                 |(index, patterns)| {
                     for pattern in patterns {
-                        index.search(pattern).count();
+                        index.search(&pattern).count();
                     }
                 },
                 BatchSize::SmallInput,
@@ -57,7 +53,7 @@ pub fn bench(c: &mut Criterion) {
                 || prepare_rlfmindex(n, prob, m),
                 |(index, patterns)| {
                     for pattern in patterns {
-                        index.search(pattern).count();
+                        index.search(&pattern).count();
                     }
                 },
                 BatchSize::SmallInput,

--- a/benches/locate.rs
+++ b/benches/locate.rs
@@ -1,5 +1,4 @@
-use fm_index::suffix_array::HasPosition;
-use fm_index::{FMIndexBackend, SearchIndexBuilder};
+use fm_index::{SearchIndexBuilder, SearchIndexWithLocate};
 
 use criterion::{criterion_group, criterion_main};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput};
@@ -11,7 +10,7 @@ fn prepare_fmindex(
     prob: f64,
     m: usize,
     l: usize,
-) -> (impl FMIndexBackend<T = u8> + HasPosition, Vec<String>) {
+) -> (impl SearchIndexWithLocate<u8>, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (
@@ -27,7 +26,7 @@ fn prepare_rlfmindex(
     prob: f64,
     m: usize,
     l: usize,
-) -> (impl FMIndexBackend<T = u8> + HasPosition, Vec<String>) {
+) -> (impl SearchIndexWithLocate<u8>, Vec<String>) {
     let (text, converter) = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
     (
@@ -51,7 +50,7 @@ pub fn bench(c: &mut Criterion) {
                 || prepare_fmindex(n, prob, m, l),
                 |(index, patterns)| {
                     for pattern in patterns {
-                        index.search(pattern).locate();
+                        index.search(&pattern).locate();
                     }
                 },
                 BatchSize::SmallInput,
@@ -63,7 +62,7 @@ pub fn bench(c: &mut Criterion) {
                 || prepare_rlfmindex(n, prob, m, l),
                 |(index, patterns)| {
                     for pattern in patterns {
-                        index.search(pattern).locate();
+                        index.search(&pattern).locate();
                     }
                 },
                 BatchSize::SmallInput,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,5 +152,7 @@ pub use crate::rlfmi::RLFMIndex;
 
 pub use builder::SearchIndexBuilder;
 pub use character::Character;
-pub use iter::{BackwardIterator, FMIndexBackend, ForwardIterator, HeapSize};
+pub use iter::{
+    BackwardIterator, FMIndexBackend, ForwardIterator, HeapSize, SearchIndex, SearchIndexWithLocate,
+};
 pub use search::Search;

--- a/src/search.rs
+++ b/src/search.rs
@@ -27,7 +27,7 @@ where
         Search {
             index,
             s: 0,
-            e: index.len(),
+            e: index.len::<seal::Local>(),
             pattern: vec![],
         }
     }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1,8 +1,8 @@
 // tests that exercise the public API, especially the traits
 
-use fm_index::{FMIndexBackend, HeapSize};
+use fm_index::{HeapSize, SearchIndex};
 
-fn len<T: FMIndexBackend>(index: &T) -> u64 {
+fn len<T: SearchIndex<u8>>(index: &T) -> u64 {
     index.len()
 }
 


### PR DESCRIPTION
These are intended to be the generic public API. FMIndexBackend is now not intended to be used in the public API at all, though it's still exposed to it because the SearchIndex trait depends on it.

The SearchIndex and SearchIndexWithLocate traits are object-safe, i.e. they're compatible with dyn. The idea is that we can then use a builder that produces a Box<dyn SearchIndex>, as this is required to support a dynamic builder that picks the backend based on the builder parameters. I haven't implemented this new builder yet, but this is a prerequisite for that.

Unfortunately to make SearchIndex object-safe I can't use the generic K argument to `search` anymore. This is used to easily take an AsRef and is especially useful when you pass in a string. I've instead come up with a solution using dyn, which has some performance overhead but I suspect it's really tiny so we should be okay.

That solution is not the exact equivalent of AsRef; you have to manually `&` the string to make a reference to make it work. I think that's acceptable enough.