### PR TITLE
Fix incorrect heap size calculation

### DIFF
--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -105,9 +105,7 @@ where
     ///
     /// No suffix array information is stored in this index.
     pub fn size(&self) -> usize {
-        std::mem::size_of::<Self>()
-            + self.bw.heap_size()
-            + self.cs.len() * std::mem::size_of::<Vec<u64>>()
+        self.bw.heap_size() + self.cs.capacity() * std::mem::size_of::<u64>()
     }
 }
 
@@ -120,9 +118,8 @@ where
     ///
     /// Sampled suffix array data is stored in this index.
     pub fn size(&self) -> usize {
-        std::mem::size_of::<Self>()
-            + self.bw.heap_size()
-            + self.cs.len() * std::mem::size_of::<Vec<u64>>()
+        self.bw.heap_size()
+            + self.cs.capacity() * std::mem::size_of::<u64>()
             + self.suffix_array.size()
     }
 }

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -149,11 +149,10 @@ where
     ///
     /// No suffix array information is stored in this index.
     pub fn size(&self) -> usize {
-        std::mem::size_of::<Self>()
-            + self.s.heap_size()
+        self.s.heap_size()
             + self.b.heap_size()
             + self.bp.heap_size()
-            + self.cs.len() * std::mem::size_of::<Vec<u64>>()
+            + self.cs.capacity() * std::mem::size_of::<u64>()
     }
 }
 
@@ -166,11 +165,10 @@ where
     ///
     /// Sampled suffix array data is stored in this index.
     pub fn size(&self) -> usize {
-        std::mem::size_of::<Self>()
-            + self.s.heap_size()
+        self.s.heap_size()
             + self.b.heap_size()
             + self.bp.heap_size()
-            + self.cs.len() * std::mem::size_of::<Vec<u64>>()
+            + self.cs.capacity() * std::mem::size_of::<u64>()
             + self.suffix_array.size()
     }
 }

--- a/src/suffix_array/sample.rs
+++ b/src/suffix_array/sample.rs
@@ -30,7 +30,7 @@ impl SuffixOrderSampledArray {
     }
 
     pub(crate) fn size(&self) -> usize {
-        std::mem::size_of::<Self>() + self.sa.heap_size()
+        self.sa.heap_size()
     }
 }
 


### PR DESCRIPTION
This PR fixes the incorrect heap size calculation in the FM-index implementations and suffix arrays, as reported in #54.