### PR TITLE
Make `sais::build_suffix_array` aware of end marker order

### DIFF
--- a/src/suffix_array/sais.rs
+++ b/src/suffix_array/sais.rs
@@ -443,6 +443,14 @@ mod tests {
     }
 
     #[test]
+    fn test_sais_starting_with_zero() {
+        let text = b"\0\0mm\0\0ii\0s\0\0\0sii\0ssii\0ppii\0".to_vec();
+        let sa = build_suffix_array(&text, &RangeConverter::new(b'a', b'z'));
+        let expected = build_expected_suffix_array(text);
+        assert_eq!(sa, expected);
+    }
+
+    #[test]
     fn test_sais_small() {
         let mut text = "mmiissiissiippii".to_string().into_bytes();
         text.push(0);


### PR DESCRIPTION
This PR makes sure `sais::build_suffix_array()` must be aware of end marker zeros. Suppose that a text is represented as $`T = T_1$_1T_2$_2\cdots T_n$_n`$, where $`T_i`$ is i-th sub-text and $`\$_i`$ is the end marker of i-th sub-text. Now when building a suffix array, $`\$_i`$ is considered smaller than $`\$_j`$ if $`i < j`$.