### PR TITLE
Add APIs to search multiple texts

### DIFF
--- a/examples/multi_text.rs
+++ b/examples/multi_text.rs
@@ -1,0 +1,71 @@
+use fm_index::converter::IdConverter;
+use fm_index::{Match, MatchWithTextId, MultiTextFMIndexWithLocate, Search};
+
+fn main() {
+    // When using MultiTextFMIndex, the text is concatenated with an end marker \0.
+    let text = concat!(
+        // 1
+        "Twinkle, twinkle, little star,\n",
+        "How I wonder what you are!\n",
+        "Up above the world so high,\n",
+        "Like a diamond in the sky.\n",
+        "Twinkle, twinkle, little star,\n",
+        "How I wonder what you are!\n\0",
+        // 2
+        "When the blazing sun is gone,\n",
+        "When he nothing shines upon,\n",
+        "Then you show your little light,\n",
+        "Twinkle, twinkle, all the night.\n",
+        "Twinkle, twinkle, little star,\n",
+        "How I wonder what you are!\n\0",
+        // 3
+        "Then the traveller in the dark,\n",
+        "Thanks you for your tiny spark;\n",
+        "He could not see which way to go,\n",
+        "If you did not twinkle so.\n",
+        "Twinkle, twinkle, little star,\n",
+        "How I wonder what you are!\n\0",
+    );
+
+    // Converter converts each character into packed representation.
+    // IdConverter represents an identity converter, which preserves the given characters.
+    let converter = IdConverter::new::<u8>();
+
+    let fm_index = MultiTextFMIndexWithLocate::new(text.as_bytes().to_vec(), converter, 2);
+
+    // Count the number of occurrences.
+    assert_eq!(4, fm_index.search("star").count());
+
+    // List the text IDs of all occurrences.
+    let mut text_ids = fm_index
+        .search("How I wonder")
+        .iter_matches()
+        .map(|m| m.text_id().into())
+        .collect::<Vec<u64>>();
+    text_ids.sort();
+    assert_eq!(vec![0, 0, 1, 2], text_ids);
+
+    // Extract preceding characters from a search position.
+    let preceding_chars = fm_index
+        .search(" in the dark")
+        .iter_matches()
+        .map(|m| {
+            m.iter_chars_backward()
+                .take_while(|c| *c != b' ')
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(vec![b"rellevart".to_vec()], preceding_chars);
+
+    // As of this writing, MultiTextFMIndex cannot extract succeeding characters from a search position
+    // due to the lack of FL-mapping implementation.
+    // let prefix = fm_index
+    //     .search(" in the dark")
+    //     .iter_matches()
+    //     .map(|m| {
+    //         m.iter_chars_forward()
+    //             .take_while(|c| *c != b' ')
+    //             .collect::<Vec<_>>()
+    //     })
+    //     .collect::<Vec<_>>();
+}

--- a/examples/multi_text.rs
+++ b/examples/multi_text.rs
@@ -4,21 +4,21 @@ use fm_index::{Match, MatchWithTextId, MultiTextFMIndexWithLocate, Search};
 fn main() {
     // When using MultiTextFMIndex, the text is concatenated with an end marker \0.
     let text = concat!(
-        // 1
+        // 0
         "Twinkle, twinkle, little star,\n",
         "How I wonder what you are!\n",
         "Up above the world so high,\n",
         "Like a diamond in the sky.\n",
         "Twinkle, twinkle, little star,\n",
         "How I wonder what you are!\n\0",
-        // 2
+        // 1
         "When the blazing sun is gone,\n",
         "When he nothing shines upon,\n",
         "Then you show your little light,\n",
         "Twinkle, twinkle, all the night.\n",
         "Twinkle, twinkle, little star,\n",
         "How I wonder what you are!\n\0",
-        // 3
+        // 2
         "Then the traveller in the dark,\n",
         "Thanks you for your tiny spark;\n",
         "He could not see which way to go,\n",

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -47,5 +47,5 @@ pub(crate) trait HasPosition {
 /// A trait for an index that contains multiple texts.
 pub(crate) trait HasMultiTexts {
     /// Returns the ID of the text that the character at the given position on the suffix array belongs to.
-    fn get_text_id(&self, i: u64) -> TextId;
+    fn text_id(&self, i: u64) -> TextId;
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,5 +1,6 @@
 use crate::character::Character;
 use crate::converter::Converter;
+use crate::text::TextId;
 
 /// Trait for an FM-Index backend implementation
 pub(crate) trait SearchIndexBackend: Sized {
@@ -41,4 +42,10 @@ pub trait HeapSize {
 /// A trait for an index that supports locate queries.
 pub(crate) trait HasPosition {
     fn get_sa(&self, i: u64) -> u64;
+}
+
+/// A trait for an index that contains multiple texts.
+pub(crate) trait HasMultiTexts {
+    /// Returns the ID of the text that the character at the given position on the suffix array belongs to.
+    fn get_text_id(&self, i: u64) -> TextId;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,7 @@ mod frontend;
 mod multi_text;
 mod rlfmi;
 mod suffix_array;
+mod text;
 mod util;
 mod wrapper;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,8 +150,11 @@ mod wrapper;
 pub use backend::HeapSize;
 pub use character::Character;
 pub use frontend::{
-    FMIndex, FMIndexSearch, FMIndexSearchWithLocate, FMIndexWithLocate, MultiTextFMIndex,
-    MultiTextFMIndexSearch, MultiTextFMIndexSearchWithLocate, MultiTextFMIndexWithLocate,
-    RLFMIndex, RLFMIndexSearch, RLFMIndexSearchWithLocate, RLFMIndexWithLocate, Search,
-    SearchIndex, SearchIndexWithLocate, SearchWithLocate,
+    FMIndex, FMIndexMatch, FMIndexMatchWithLocate, FMIndexSearch, FMIndexSearchWithLocate,
+    FMIndexWithLocate, Match, MatchWithLocate, MatchWithTextId, MultiTextFMIndex,
+    MultiTextFMIndexMatch, MultiTextFMIndexMatchWithLocate, MultiTextFMIndexSearch,
+    MultiTextFMIndexSearchWithLocate, MultiTextFMIndexWithLocate, RLFMIndex, RLFMIndexMatch,
+    RLFMIndexMatchWithLocate, RLFMIndexSearch, RLFMIndexSearchWithLocate, RLFMIndexWithLocate,
+    Search, SearchIndex, SearchIndexWithLocate, SearchWithLocate,
 };
+pub use text::TextId;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,8 @@ mod frontend;
 mod multi_text;
 mod rlfmi;
 mod suffix_array;
+#[cfg(test)]
+mod testutil;
 mod text;
 mod util;
 mod wrapper;

--- a/src/multi_text.rs
+++ b/src/multi_text.rs
@@ -1,4 +1,4 @@
-use std::ops::Sub;
+use std::ops::{Rem, Sub};
 
 use crate::backend::{HasMultiTexts, HasPosition, SearchIndexBackend};
 use crate::character::{prepare_text, Character};
@@ -249,16 +249,11 @@ where
     }
 }
 
-fn modular_add<T: Sub<Output = T> + Ord + num_traits::Zero>(a: T, b: T, m: T) -> T {
+fn modular_add<T: Rem<Output = T> + Ord + num_traits::Zero>(a: T, b: T, m: T) -> T {
     debug_assert!(T::zero() <= a && a <= m);
     debug_assert!(T::zero() <= b && b <= m);
 
-    let sum = a + b;
-    if sum >= m {
-        sum - m
-    } else {
-        sum
-    }
+    (a + b) % m
 }
 
 fn modular_sub<T: Sub<Output = T> + Ord + num_traits::Zero>(a: T, b: T, m: T) -> T {

--- a/src/multi_text.rs
+++ b/src/multi_text.rs
@@ -1,12 +1,13 @@
 use std::ops::Sub;
 
-use crate::backend::{HasPosition, SearchIndexBackend};
+use crate::backend::{HasMultiTexts, HasPosition, SearchIndexBackend};
 use crate::character::{prepare_text, Character};
 #[cfg(doc)]
 use crate::converter;
 use crate::converter::Converter;
 use crate::suffix_array::sais;
 use crate::suffix_array::sample::SuffixOrderSampledArray;
+use crate::text::TextId;
 use crate::util;
 use crate::HeapSize;
 
@@ -226,6 +227,21 @@ where
                 }
             }
         }
+    }
+}
+
+impl<T, C, S> HasMultiTexts for MultiTextFMIndexBackend<T, C, S>
+where
+    T: Character,
+    C: Converter<T>,
+{
+    fn get_text_id(&self, i: u64) -> TextId {
+        todo!("return the text ID by iterating through texts using lf_map. See FMIndex#EnumerateDocuments in sxsi-git");
+        // let r = self
+        //     .bw
+        //     .rank_u64(i as usize, 0)
+        //     .expect("the index i must be smaller than the size of the text");
+        // TextId::from(self.doc[r] as u64)
     }
 }
 

--- a/src/multi_text.rs
+++ b/src/multi_text.rs
@@ -239,8 +239,8 @@ where
         loop {
             let c = self.get_l(i);
             if c.is_zero() {
-                let text_id_next = self.doc[self.bw.rank_u64_unchecked(i as usize, 0)];
-                let text_id = modular_add(text_id_next, 1, self.doc.len() as u64);
+                let text_id_prev = self.doc[self.bw.rank_u64_unchecked(i as usize, 0)];
+                let text_id = modular_add(text_id_prev, 1, self.doc.len() as u64);
                 return TextId::from(text_id);
             }
 

--- a/src/multi_text.rs
+++ b/src/multi_text.rs
@@ -164,7 +164,7 @@ where
         let rank = self.bw.rank_u64_unchecked(i as usize, c.into());
 
         if c.is_zero() {
-            self.doc[rank] as u64
+            self.doc[rank]
         } else {
             let c_count = self.cs[c.into() as usize];
             rank as u64 + c_count
@@ -176,7 +176,7 @@ where
         let rank = self.bw.rank_u64_unchecked(i as usize, c.into());
 
         if c.is_zero() {
-            self.doc[rank] as u64
+            self.doc[rank]
         } else {
             let c_count = self.cs[c.into() as usize];
             rank as u64 + c_count
@@ -305,7 +305,7 @@ mod tests {
     fn test_get_text_id() {
         let text = "foo\0bar\0baz\0".as_bytes();
         let converter = IdConverter::new::<u8>();
-        let suffix_array = MultiTextFMIndexBackend::<_, _, ()>::suffix_array(&text, &converter);
+        let suffix_array = MultiTextFMIndexBackend::<_, _, ()>::suffix_array(text, &converter);
         let fm_index =
             MultiTextFMIndexBackend::new(text.to_vec(), converter, |sa| sample::sample(sa, 0));
 

--- a/src/multi_text.rs
+++ b/src/multi_text.rs
@@ -284,6 +284,31 @@ mod tests {
         assert_eq!(lf_map_expected, lf_map_actual);
     }
 
+    #[test]
+    #[ignore]
+    fn test_get_text_id() {
+        let text = "foo\0bar\0baz\0".as_bytes();
+        let converter = IdConverter::new::<u8>();
+        let suffix_array = MultiTextFMIndexBackend::<_, _, ()>::suffix_array(&text, &converter);
+        let fm_index =
+            MultiTextFMIndexBackend::new(text.to_vec(), converter, |sa| sample::sample(sa, 0));
+
+        for (i, &char_pos) in suffix_array.iter().enumerate() {
+            let text_id_expected = TextId::from(
+                text[..(char_pos as usize)]
+                    .iter()
+                    .filter(|&&c| c == 0)
+                    .count() as u64,
+            );
+            let text_id_actual = fm_index.get_text_id(i as u64);
+            assert_eq!(
+                text_id_expected, text_id_actual,
+                "the text ID of a character at position {} ({} in suffix array) must be {:?}",
+                char_pos, i, text_id_expected
+            );
+        }
+    }
+
     fn generate_text_random(text_size: usize, alphabet_size: u8) -> Vec<u8> {
         let mut rng = StdRng::seed_from_u64(0);
 

--- a/src/multi_text.rs
+++ b/src/multi_text.rs
@@ -235,7 +235,7 @@ where
     T: Character,
     C: Converter<T>,
 {
-    fn get_text_id(&self, mut i: u64) -> TextId {
+    fn text_id(&self, mut i: u64) -> TextId {
         loop {
             let c = self.get_l(i);
             if c.is_zero() {
@@ -316,7 +316,7 @@ mod tests {
                     .filter(|&&c| c == 0)
                     .count() as u64,
             );
-            let text_id_actual = fm_index.get_text_id(i as u64);
+            let text_id_actual = fm_index.text_id(i as u64);
             assert_eq!(
                 text_id_expected, text_id_actual,
                 "the text ID of a character at position {} ({} in suffix array) must be {:?}",
@@ -346,7 +346,7 @@ mod tests {
                         .filter(|&&c| c == 0)
                         .count() as u64,
                 );
-                let text_id_actual = fm_index.get_text_id(i as u64);
+                let text_id_actual = fm_index.text_id(i as u64);
                 assert_eq!(
                     text_id_expected, text_id_actual,
                     "the text ID of a character at position {} ({} in suffix array) must be {:?}. text={:?}, suffix_array={:?}",

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -1,0 +1,25 @@
+use num_traits::Zero;
+
+/// Build a text for tests using a generator function `gen`.
+pub(crate) fn build_text<T: Zero, F: FnMut() -> T>(mut gen: F, len: usize) -> Vec<T> {
+    let mut text = (0..(len - 1)).map(|_| gen()).collect::<Vec<_>>();
+
+    // Truncate the trailing zeros, since SA-IS does not support trailing zero suffix longer than 1.
+    if let Some(pos) = text.iter().rposition(|x| !x.is_zero()) {
+        text.truncate(pos + 1);
+    } else {
+        text.clear();
+    }
+
+    // Add non-zero elements until the text length reaches len - 1.
+    while text.len() < len - 1 {
+        let c = gen();
+        if !c.is_zero() {
+            text.push(c);
+        }
+    }
+
+    // Add the last zero as a sentinel for SA-IS.
+    text.push(T::zero());
+    text
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -7,3 +7,9 @@ impl From<u64> for TextId {
         TextId(value)
     }
 }
+
+impl Into<u64> for TextId {
+    fn into(self) -> u64 {
+        self.0
+    }
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -1,0 +1,9 @@
+/// A unique id identifying this text.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct TextId(u64);
+
+impl From<u64> for TextId {
+    fn from(value: u64) -> Self {
+        TextId(value)
+    }
+}

--- a/src/text.rs
+++ b/src/text.rs
@@ -8,8 +8,8 @@ impl From<u64> for TextId {
     }
 }
 
-impl Into<u64> for TextId {
-    fn into(self) -> u64 {
-        self.0
+impl From<TextId> for u64 {
+    fn from(value: TextId) -> u64 {
+        value.0
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -241,7 +241,7 @@ impl<'a, B: SearchIndexBackend + HasPosition> MatchWrapper<'a, B> {
 }
 
 impl<'a, B: SearchIndexBackend + HasMultiTexts> MatchWrapper<'a, B> {
-    pub(crate) fn get_text_id(&self) -> TextId {
-        self.backend.get_text_id(self.i)
+    pub(crate) fn text_id(&self) -> TextId {
+        self.backend.text_id(self.i)
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -234,13 +234,13 @@ impl<'a, B: SearchIndexBackend> MatchWrapper<'a, B> {
     }
 }
 
-impl<'a, B: SearchIndexBackend + HasPosition> MatchWrapper<'a, B> {
+impl<B: SearchIndexBackend + HasPosition> MatchWrapper<'_, B> {
     pub(crate) fn locate(&self) -> u64 {
         self.backend.get_sa(self.i)
     }
 }
 
-impl<'a, B: SearchIndexBackend + HasMultiTexts> MatchWrapper<'a, B> {
+impl<B: SearchIndexBackend + HasMultiTexts> MatchWrapper<'_, B> {
     pub(crate) fn text_id(&self) -> TextId {
         self.backend.text_id(self.i)
     }

--- a/tests/test_multitext.rs
+++ b/tests/test_multitext.rs
@@ -1,6 +1,8 @@
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
-use fm_index::{converter::IdConverter, MultiTextFMIndexWithLocate};
+mod testutil;
+use fm_index::converter::IdConverter;
+use fm_index::{MatchWithLocate, MatchWithTextId, MultiTextFMIndexWithLocate, Search, TextId};
 
 #[test]
 fn test_search_count() {
@@ -61,6 +63,86 @@ fn test_search_locate() {
 
         assert_eq!(
             positions_expected, positions_actual,
+            "i = {:?}, text = {:?}, pattern = {:?}",
+            i, text, pattern
+        );
+    }
+}
+
+#[test]
+fn test_search_iter_matches_locate() {
+    let text_size = 1024;
+    let alphabet_size = 8;
+    let pattern_size_max = 128;
+
+    let mut rng = StdRng::seed_from_u64(0);
+    let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
+
+    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 0);
+
+    for i in 0..1000 {
+        let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
+        let pattern = (0..pattern_size)
+            .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
+            .collect::<Vec<_>>();
+
+        let mut positions_expected = Vec::new();
+        for i in 0..=(text_size - pattern_size) {
+            if text[i..i + pattern_size] == pattern {
+                positions_expected.push(i as u64);
+            }
+        }
+        let mut positions_actual = fm_index
+            .search(&pattern)
+            .iter_matches()
+            .map(|m| m.locate())
+            .collect::<Vec<_>>();
+        positions_actual.sort();
+
+        assert_eq!(
+            positions_expected, positions_actual,
+            "i = {:?}, text = {:?}, pattern = {:?}",
+            i, text, pattern
+        );
+    }
+}
+
+#[test]
+fn test_search_iter_matches_text_id() {
+    let text_size = 1024;
+    let alphabet_size = 8;
+    let pattern_size_max = 128;
+
+    let mut rng = StdRng::seed_from_u64(0);
+    let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
+
+    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 0);
+
+    for i in 0..1000 {
+        let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
+        let pattern = (0..pattern_size)
+            .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
+            .collect::<Vec<_>>();
+
+        let mut text_ids_expected = Vec::new();
+        let mut text_id = 0;
+        for i in 0..=(text_size - pattern_size) {
+            if text[i] == 0 {
+                text_id += 1;
+            }
+            if text[i..i + pattern_size] == pattern {
+                text_ids_expected.push(TextId::from(text_id));
+            }
+        }
+        let mut text_ids_actual = fm_index
+            .search(&pattern)
+            .iter_matches()
+            .map(|m| m.text_id())
+            .collect::<Vec<_>>();
+        text_ids_actual.sort();
+
+        assert_eq!(
+            text_ids_expected, text_ids_actual,
             "i = {:?}, text = {:?}, pattern = {:?}",
             i, text, pattern
         );

--- a/tests/testutil/mod.rs
+++ b/tests/testutil/mod.rs
@@ -1,0 +1,25 @@
+use num_traits::Zero;
+
+/// Build a text for tests using a generator function `gen`.
+pub(crate) fn build_text<T: Zero, F: FnMut() -> T>(mut gen: F, len: usize) -> Vec<T> {
+    let mut text = (0..(len - 1)).map(|_| gen()).collect::<Vec<_>>();
+
+    // Truncate the trailing zeros, since SA-IS does not support trailing zero suffix longer than 1.
+    if let Some(pos) = text.iter().rposition(|x| !x.is_zero()) {
+        text.truncate(pos + 1);
+    } else {
+        text.clear();
+    }
+
+    // Add non-zero elements until the text length reaches len - 1.
+    while text.len() < len - 1 {
+        let c = gen();
+        if !c.is_zero() {
+            text.push(c);
+        }
+    }
+
+    // Add the last zero as a sentinel for SA-IS.
+    text.push(T::zero());
+    text
+}


### PR DESCRIPTION
This PR adds frontend APIs for `MultiTextFMIndex`.

Notably, a new method `iter_matches` is added to the `Search` trait in the frontend. This method returns an iterator of `Match` instances, which correspond to each position matched with the pattern. The `Match` instance provides

- `iter_chars_forward`: iterates over the characters of the match
- `iter_chars_backward`: iterates over the characters of the match in reverse
- `locate`: gets the location of the matched pattern
- `text_id`: gets the ID of the text that the character at the matched position belongs to.

This design is inspired by `LocationInfoIterator` in #33, but here I avoided the use of the term "location" to about naming structs like `FMIndexLocationInfoWithLocate`.