### PR TITLE
Integrate Multi-Text FM Index with SA-IS

### DIFF
--- a/examples/multi_text.rs
+++ b/examples/multi_text.rs
@@ -57,15 +57,18 @@ fn main() {
         .collect::<Vec<_>>();
     assert_eq!(vec![b"rellevart".to_vec()], preceding_chars);
 
-    // As of this writing, MultiTextFMIndex cannot extract succeeding characters from a search position
-    // due to the lack of FL-mapping implementation.
-    // let prefix = fm_index
-    //     .search(" in the dark")
-    //     .iter_matches()
-    //     .map(|m| {
-    //         m.iter_chars_forward()
-    //             .take_while(|c| *c != b' ')
-    //             .collect::<Vec<_>>()
-    //     })
-    //     .collect::<Vec<_>>();
+    // Extract succeeding characters from a search position.
+    let succeeding_chars = fm_index
+        .search("ing ")
+        .iter_matches()
+        .map(|m| {
+            m.iter_chars_forward()
+                .take_while(|c| *c != b',')
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        vec![b"ing shines upon".to_vec(), b"ing sun is gone".to_vec()],
+        succeeding_chars,
+    );
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -12,13 +12,13 @@ pub(crate) trait SearchIndexBackend: Sized {
 
     fn get_l(&self, i: u64) -> Self::T;
 
-    fn lf_map(&self, i: u64) -> u64;
+    fn lf_map(&self, i: u64) -> Option<u64>;
 
-    fn lf_map2(&self, c: Self::T, i: u64) -> u64;
+    fn lf_map2(&self, c: Self::T, i: u64) -> Option<u64>;
 
     fn get_f(&self, i: u64) -> Self::T;
 
-    fn fl_map(&self, i: u64) -> u64;
+    fn fl_map(&self, i: u64) -> Option<u64>;
 
     /// The size of the text in the index
     ///

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -77,8 +77,14 @@ where
         let mut e = self.e;
         let mut pattern = pattern.as_ref().to_vec();
         for &c in pattern.iter().rev() {
-            s = self.backend.lf_map2(c, s);
-            e = self.backend.lf_map2(c, e);
+            let s_mapped = self.backend.lf_map2(c, s);
+            let e_mapped = self.backend.lf_map2(c, e);
+            if let (Some(s_mapped), Some(e_mapped)) = (s_mapped, e_mapped) {
+                s = s_mapped;
+                e = e_mapped;
+            } else {
+                todo!("return a Result instead of panicking");
+            }
             if s == e {
                 break;
             }
@@ -163,7 +169,7 @@ impl<B: SearchIndexBackend> Iterator for BackwardIteratorWrapper<'_, B> {
     type Item = B::T;
     fn next(&mut self) -> Option<Self::Item> {
         let c = self.backend.get_l(self.i);
-        self.i = self.backend.lf_map(self.i);
+        self.i = self.backend.lf_map(self.i)?;
         Some(self.backend.get_converter().convert_inv(c))
     }
 }
@@ -185,7 +191,7 @@ impl<B: SearchIndexBackend> Iterator for ForwardIteratorWrapper<'_, B> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let c = self.backend.get_f(self.i);
-        self.i = self.backend.fl_map(self.i);
+        self.i = self.backend.fl_map(self.i)?;
         Some(self.backend.get_converter().convert_inv(c))
     }
 }

--- a/tests/test_multitext.rs
+++ b/tests/test_multitext.rs
@@ -9,11 +9,11 @@ fn test_search_count() {
     let text_size = 1024;
     let alphabet_size = 8;
     let pattern_size_max = 128;
-    let text = generate_text_random(text_size, alphabet_size);
-
-    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 0);
 
     let mut rng = StdRng::seed_from_u64(0);
+    let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
+    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 0);
+
     for i in 0..1000 {
         let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
         let pattern = (0..pattern_size)
@@ -41,11 +41,11 @@ fn test_search_locate() {
     let text_size = 1024;
     let alphabet_size = 8;
     let pattern_size_max = 128;
-    let text = generate_text_random(text_size, alphabet_size);
-
-    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 0);
 
     let mut rng = StdRng::seed_from_u64(0);
+    let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
+    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 0);
+
     for i in 0..1000 {
         let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
         let pattern = (0..pattern_size)
@@ -147,12 +147,4 @@ fn test_search_iter_matches_text_id() {
             i, text, pattern
         );
     }
-}
-
-fn generate_text_random(text_size: usize, alphabet_size: u8) -> Vec<u8> {
-    let mut rng = StdRng::seed_from_u64(0);
-
-    (0..text_size)
-        .map(|_| rng.gen::<u8>() % alphabet_size)
-        .collect::<Vec<_>>()
 }

--- a/tests/testutil/mod.rs
+++ b/tests/testutil/mod.rs
@@ -1,25 +1,24 @@
 use num_traits::Zero;
 
 /// Build a text for tests using a generator function `gen`.
-pub(crate) fn build_text<T: Zero, F: FnMut() -> T>(mut gen: F, len: usize) -> Vec<T> {
-    let mut text = (0..(len - 1)).map(|_| gen()).collect::<Vec<_>>();
+pub fn build_text<T: Zero + Clone, F: FnMut() -> T>(mut gen: F, len: usize) -> Vec<T> {
+    let mut text = vec![T::zero(); len];
 
-    // Truncate the trailing zeros, since SA-IS does not support trailing zero suffix longer than 1.
-    if let Some(pos) = text.iter().rposition(|x| !x.is_zero()) {
-        text.truncate(pos + 1);
-    } else {
-        text.clear();
-    }
-
-    // Add non-zero elements until the text length reaches len - 1.
-    while text.len() < len - 1 {
-        let c = gen();
-        if !c.is_zero() {
-            text.push(c);
+    let mut prev_zero = true;
+    for t in text.iter_mut().take(len - 1) {
+        let mut c = gen();
+        if prev_zero {
+            while c.is_zero() {
+                c = gen();
+            }
         }
+        prev_zero = c.is_zero();
+        *t = c;
     }
 
-    // Add the last zero as a sentinel for SA-IS.
-    text.push(T::zero());
+    while text[len - 2].is_zero() {
+        text[len - 2] = gen();
+    }
+
     text
 }


### PR DESCRIPTION
This PR updates Multi-Text FM-Index to adopt SA-IS to build the suffix array.

As written in https://github.com/ajalab/fm-index/pull/73#issuecomment-2717869510, since SA-IS itself doesn't sort end-markers `\0` in the order of their positions in the text, we cannot perform LF-mapping nor FL-mapping for the end-markers anymore. Thus, `lf_map` and `fl_map` in `SearchIndexBackend` now returns `Optional`.

This also means that we cannot include `\0` in the search patterns like `fm_index.search("\0When")` to find texts prefixed by the pattern. We need to provide different APIs to offer such features. I'll work on it in #68.