### PR TITLE
Provide methods for multi-text search

### DIFF
--- a/examples/multi_text.rs
+++ b/examples/multi_text.rs
@@ -71,4 +71,13 @@ fn main() {
         vec![b"ing shines upon".to_vec(), b"ing sun is gone".to_vec()],
         succeeding_chars,
     );
+
+    // List the IDs of texts that have the suffix.
+    let mut text_ids_with_suffix = fm_index
+        .search_suffix("what you are!\n")
+        .iter_matches()
+        .map(|m| m.text_id().into())
+        .collect::<Vec<u64>>();
+    text_ids_with_suffix.sort();
+    assert_eq!(vec![0, 1, 2], text_ids_with_suffix);
 }

--- a/examples/multi_text.rs
+++ b/examples/multi_text.rs
@@ -72,6 +72,15 @@ fn main() {
         succeeding_chars,
     );
 
+    // List the IDs of texts that have the prefix.
+    let mut text_ids_with_prefix = fm_index
+        .search_prefix("Twinkle")
+        .iter_matches()
+        .map(|m| m.text_id().into())
+        .collect::<Vec<u64>>();
+    text_ids_with_prefix.sort();
+    assert_eq!(vec![0], text_ids_with_prefix);
+
     // List the IDs of texts that have the suffix.
     let mut text_ids_with_suffix = fm_index
         .search_suffix("what you are!\n")

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -48,4 +48,7 @@ pub(crate) trait HasPosition {
 pub(crate) trait HasMultiTexts {
     /// Returns the ID of the text that the character at the given position on the suffix array belongs to.
     fn text_id(&self, i: u64) -> TextId;
+
+    /// Returns the number of texts in the index.
+    fn text_count(&self) -> u64;
 }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -61,6 +61,11 @@ pub trait SearchIndexWithMultiTexts<T>: SearchIndex<T> {
     fn search_suffix<K>(&self, pattern: K) -> impl Search<T>
     where
         K: AsRef<[T]>;
+
+    /// Search for a pattern that is an exact match of a text.
+    fn search_exact<K>(&self, pattern: K) -> impl Search<T>
+    where
+        K: AsRef<[T]>;
 }
 
 /// The result of a search.
@@ -385,6 +390,13 @@ macro_rules! impl_search_index_with_multi_texts {
             {
                 $s(self.0.search_suffix(pattern))
             }
+
+            fn search_exact<K>(&self, pattern: K) -> impl Search<T>
+            where
+                K: AsRef<[T]>,
+            {
+                $s(self.0.search_exact(pattern))
+            }
         }
 
         // inherent
@@ -403,6 +415,14 @@ macro_rules! impl_search_index_with_multi_texts {
                 K: AsRef<[T]>,
             {
                 $s(self.0.search_suffix(pattern))
+            }
+
+            /// Search for a pattern that is an exact match of a text.
+            pub fn search_exact<K>(&self, pattern: K) -> $st
+            where
+                K: AsRef<[T]>,
+            {
+                $s(self.0.search_exact(pattern))
             }
         }
     };

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -50,6 +50,14 @@ pub trait SearchIndexWithLocate<T>: SearchIndex<T> {
         K: AsRef<[T]>;
 }
 
+/// Trait for searching in an index that supports multiple texts.
+pub trait SearchIndexWithMultiTexts<T>: SearchIndex<T> {
+    /// Search for a pattern that is a suffix of a text.
+    fn search_suffix<K>(&self, pattern: K) -> impl Search<T>
+    where
+        K: AsRef<[T]>;
+}
+
 /// The result of a search.
 ///
 /// A search result can be refined by adding more characters to the
@@ -356,6 +364,30 @@ macro_rules! impl_search_index_with_locate {
     };
 }
 
+macro_rules! impl_search_index_with_multi_texts {
+    ($t:ty, $s:ident, $st:ty) => {
+        impl<T: Character, C: Converter<T>> SearchIndexWithMultiTexts<T> for $t {
+            fn search_suffix<K>(&self, pattern: K) -> impl Search<T>
+            where
+                K: AsRef<[T]>,
+            {
+                $s(self.0.search_suffix(pattern))
+            }
+        }
+
+        // inherent
+        impl<T: Character, C: Converter<T>> $t {
+            /// Search for a pattern in the text.
+            pub fn search_suffix<K>(&self, pattern: K) -> $st
+            where
+                K: AsRef<[T]>,
+            {
+                $s(self.0.search_suffix(pattern))
+            }
+        }
+    };
+}
+
 macro_rules! impl_search {
     ($t:ty, $m:ident, $mt:ty) => {
         impl<'a, T: Character, C: Converter<T>> Search<'a, T> for $t {
@@ -505,6 +537,7 @@ impl_match!(RLFMIndexMatchWithLocate<'a, T, C>);
 impl_match_locate!(RLFMIndexMatchWithLocate<'a, T, C>);
 
 impl_search_index!(MultiTextFMIndex<T, C>, MultiTextFMIndexSearch, MultiTextFMIndexSearch<T, C>);
+impl_search_index_with_multi_texts!(MultiTextFMIndex<T, C>, MultiTextFMIndexSearch, MultiTextFMIndexSearch<T, C>);
 impl_search!(
     MultiTextFMIndexSearch<'a, T, C>,
     MultiTextFMIndexMatch,
@@ -513,6 +546,7 @@ impl_search!(
 impl_match!(MultiTextFMIndexMatch<'a, T, C>);
 
 impl_search_index_with_locate!(MultiTextFMIndexWithLocate<T, C>, MultiTextFMIndexSearchWithLocate, MultiTextFMIndexSearchWithLocate<T, C>);
+impl_search_index_with_multi_texts!(MultiTextFMIndexWithLocate<T, C>, MultiTextFMIndexSearchWithLocate, MultiTextFMIndexSearchWithLocate<T, C>);
 impl_search!(
     MultiTextFMIndexSearchWithLocate<'a, T, C>,
     MultiTextFMIndexMatchWithLocate,

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -52,6 +52,11 @@ pub trait SearchIndexWithLocate<T>: SearchIndex<T> {
 
 /// Trait for searching in an index that supports multiple texts.
 pub trait SearchIndexWithMultiTexts<T>: SearchIndex<T> {
+    /// Search for a pattern that is a prefix of a text.
+    fn search_prefix<K>(&self, pattern: K) -> impl Search<T>
+    where
+        K: AsRef<[T]>;
+
     /// Search for a pattern that is a suffix of a text.
     fn search_suffix<K>(&self, pattern: K) -> impl Search<T>
     where
@@ -367,6 +372,13 @@ macro_rules! impl_search_index_with_locate {
 macro_rules! impl_search_index_with_multi_texts {
     ($t:ty, $s:ident, $st:ty) => {
         impl<T: Character, C: Converter<T>> SearchIndexWithMultiTexts<T> for $t {
+            fn search_prefix<K>(&self, pattern: K) -> impl Search<T>
+            where
+                K: AsRef<[T]>,
+            {
+                $s(self.0.search_prefix(pattern))
+            }
+
             fn search_suffix<K>(&self, pattern: K) -> impl Search<T>
             where
                 K: AsRef<[T]>,
@@ -377,7 +389,15 @@ macro_rules! impl_search_index_with_multi_texts {
 
         // inherent
         impl<T: Character, C: Converter<T>> $t {
-            /// Search for a pattern in the text.
+            /// Search for a pattern that is a prefix of a text.
+            pub fn search_prefix<K>(&self, pattern: K) -> $st
+            where
+                K: AsRef<[T]>,
+            {
+                $s(self.0.search_prefix(pattern))
+            }
+
+            /// Search for a pattern that is a suffix of a text.
             pub fn search_suffix<K>(&self, pattern: K) -> $st
             where
                 K: AsRef<[T]>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,6 @@ pub use frontend::{
     MultiTextFMIndexMatch, MultiTextFMIndexMatchWithLocate, MultiTextFMIndexSearch,
     MultiTextFMIndexSearchWithLocate, MultiTextFMIndexWithLocate, RLFMIndex, RLFMIndexMatch,
     RLFMIndexMatchWithLocate, RLFMIndexSearch, RLFMIndexSearchWithLocate, RLFMIndexWithLocate,
-    Search, SearchIndex, SearchIndexWithLocate, SearchWithLocate,
+    Search, SearchIndex, SearchIndexWithLocate, SearchIndexWithMultiTexts, SearchWithLocate,
 };
 pub use text::TextId;

--- a/src/multi_text.rs
+++ b/src/multi_text.rs
@@ -236,6 +236,10 @@ where
             }
         }
     }
+
+    fn text_count(&self) -> u64 {
+        self.doc.len() as u64
+    }
 }
 
 fn modular_add<T: Rem<Output = T> + Ord + num_traits::Zero>(a: T, b: T, m: T) -> T {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -74,6 +74,14 @@ where
     {
         SearchWrapper::new(&self.0, 0, self.0.text_count(), false).search(pattern)
     }
+
+    /// Search for a pattern that is an exact match of a text.
+    pub(crate) fn search_exact<K>(&self, pattern: K) -> SearchWrapper<B>
+    where
+        K: AsRef<[B::T]>,
+    {
+        SearchWrapper::new(&self.0, 0, self.0.text_count(), true).search(pattern)
+    }
 }
 
 impl<'a, B> SearchWrapper<'a, B>

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -37,7 +37,7 @@ where
     where
         K: AsRef<[B::T]>,
     {
-        SearchWrapper::new(&self.0).search(pattern)
+        SearchWrapper::new(&self.0, 0, self.0.len()).search(pattern)
     }
 
     /// Get the length of the text in the index.
@@ -53,15 +53,27 @@ where
     }
 }
 
+impl<B> SearchIndexWrapper<B>
+where
+    B: SearchIndexBackend + HasMultiTexts,
+{
+    /// Search for the text which has the given suffix.
+    pub(crate) fn search_suffix<K>(&self, pattern: K) -> SearchWrapper<B>
+    where
+        K: AsRef<[B::T]>,
+    {
+        SearchWrapper::new(&self.0, 0, self.0.text_count()).search(pattern)
+    }
+}
+
 impl<'a, B> SearchWrapper<'a, B>
 where
     B: SearchIndexBackend,
 {
-    fn new(backend: &'a B) -> Self {
-        let e = backend.len();
+    fn new(backend: &'a B, s: u64, e: u64) -> Self {
         SearchWrapper {
             backend,
-            s: 0,
+            s,
             e,
             pattern: vec![],
         }

--- a/tests/test_multitext.rs
+++ b/tests/test_multitext.rs
@@ -1,67 +1,62 @@
-use rand::{rngs::StdRng, Rng, SeedableRng};
-
 mod testutil;
 use fm_index::converter::IdConverter;
 use fm_index::{MatchWithLocate, MatchWithTextId, MultiTextFMIndexWithLocate, Search, TextId};
+use testutil::TestRunner;
 
 #[test]
 fn test_search_count() {
-    let texts = 100;
-    let patterns = 100;
     let text_size = 1024;
-    let alphabet_size = 8;
-    let pattern_size_max = 10;
 
-    let mut rng = StdRng::seed_from_u64(0);
-    for _ in 0..texts {
-        let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
-        let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
-
-        for i in 0..patterns {
-            let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
-            let pattern = (0..pattern_size)
-                .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
-                .collect::<Vec<_>>();
-
+    TestRunner {
+        texts: 100,
+        patterns: 100,
+        text_size,
+        alphabet_size: 8,
+        level_max: 3,
+        pattern_size_max: 10,
+    }
+    .run(
+        |text, level| {
+            MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), level)
+        },
+        |fm_index, text, pattern| {
             let mut count_expected = 0;
-            for i in 0..=(text_size - pattern_size) {
-                if text[i..i + pattern_size] == pattern {
+            for i in 0..=(text_size - pattern.len()) {
+                if &text[i..i + pattern.len()] == pattern {
                     count_expected += 1;
                 }
             }
-            let count_actual = fm_index.search(&pattern).count();
+            let count_actual = fm_index.search(pattern).count();
 
             assert_eq!(
                 count_expected, count_actual,
-                "i = {:?}, text = {:?}, pattern = {:?}",
-                i, text, pattern
+                "text = {:?}, pattern = {:?}",
+                text, pattern
             );
-        }
-    }
+        },
+    );
 }
 
 #[test]
 fn test_search_locate() {
-    let texts = 100;
-    let patterns = 100;
     let text_size = 1024;
-    let alphabet_size = 8;
-    let pattern_size_max = 10;
 
-    let mut rng = StdRng::seed_from_u64(0);
-    for _ in 0..texts {
-        let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
-        let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
-
-        for i in 0..patterns {
-            let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
-            let pattern = (0..pattern_size)
-                .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
-                .collect::<Vec<_>>();
-
+    TestRunner {
+        texts: 100,
+        patterns: 100,
+        text_size,
+        alphabet_size: 8,
+        level_max: 3,
+        pattern_size_max: 10,
+    }
+    .run(
+        |text, level| {
+            MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), level)
+        },
+        |fm_index, text, pattern| {
             let mut positions_expected = Vec::new();
-            for i in 0..=(text_size - pattern_size) {
-                if text[i..i + pattern_size] == pattern {
+            for i in 0..=(text_size - pattern.len()) {
+                if &text[i..i + pattern.len()] == pattern {
                     positions_expected.push(i as u64);
                 }
             }
@@ -70,36 +65,33 @@ fn test_search_locate() {
 
             assert_eq!(
                 positions_expected, positions_actual,
-                "i = {:?}, text = {:?}, pattern = {:?}",
-                i, text, pattern
+                "text = {:?}, pattern = {:?}",
+                text, pattern
             );
-        }
-    }
+        },
+    );
 }
 
 #[test]
 fn test_search_iter_matches_locate() {
-    let texts = 100;
-    let patterns = 100;
     let text_size = 1024;
-    let alphabet_size = 8;
-    let pattern_size_max = 10;
 
-    let mut rng = StdRng::seed_from_u64(0);
-
-    for _ in 0..texts {
-        let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
-        let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
-
-        for i in 0..patterns {
-            let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
-            let pattern = (0..pattern_size)
-                .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
-                .collect::<Vec<_>>();
-
+    TestRunner {
+        texts: 100,
+        patterns: 100,
+        text_size,
+        alphabet_size: 8,
+        level_max: 3,
+        pattern_size_max: 10,
+    }
+    .run(
+        |text, level| {
+            MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), level)
+        },
+        |fm_index, text, pattern| {
             let mut positions_expected = Vec::new();
-            for i in 0..=(text_size - pattern_size) {
-                if text[i..i + pattern_size] == pattern {
+            for i in 0..=(text_size - pattern.len()) {
+                if &text[i..i + pattern.len()] == pattern {
                     positions_expected.push(i as u64);
                 }
             }
@@ -112,39 +104,37 @@ fn test_search_iter_matches_locate() {
 
             assert_eq!(
                 positions_expected, positions_actual,
-                "i = {:?}, text = {:?}, pattern = {:?}",
-                i, text, pattern
+                "text = {:?}, pattern = {:?}",
+                text, pattern
             );
-        }
-    }
+        },
+    );
 }
 
 #[test]
 fn test_search_iter_matches_text_id() {
-    let texts = 100;
-    let patterns = 100;
     let text_size = 1024;
-    let alphabet_size = 8;
-    let pattern_size_max = 10;
 
-    let mut rng = StdRng::seed_from_u64(0);
-    for _ in 0..texts {
-        let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
-        let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
-
-        for i in 0..patterns {
-            let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
-            let pattern = (0..pattern_size)
-                .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
-                .collect::<Vec<_>>();
-
+    TestRunner {
+        texts: 100,
+        patterns: 100,
+        text_size,
+        alphabet_size: 8,
+        level_max: 3,
+        pattern_size_max: 10,
+    }
+    .run(
+        |text, level| {
+            MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), level)
+        },
+        |fm_index, text, pattern| {
             let mut text_ids_expected = Vec::new();
             let mut text_id = 0;
-            for i in 0..=(text_size - pattern_size) {
+            for i in 0..=(text_size - pattern.len()) {
                 if text[i] == 0 {
                     text_id += 1;
                 }
-                if text[i..i + pattern_size] == pattern {
+                if &text[i..i + pattern.len()] == pattern {
                     text_ids_expected.push(TextId::from(text_id));
                 }
             }
@@ -157,9 +147,9 @@ fn test_search_iter_matches_text_id() {
 
             assert_eq!(
                 text_ids_expected, text_ids_actual,
-                "i = {:?}, text = {:?}, pattern = {:?}",
-                i, text, pattern
+                "text = {:?}, pattern = {:?}",
+                text, pattern
             );
-        }
-    }
+        },
+    );
 }

--- a/tests/test_multitext.rs
+++ b/tests/test_multitext.rs
@@ -60,7 +60,7 @@ fn test_search_locate() {
                     positions_expected.push(i as u64);
                 }
             }
-            let mut positions_actual = fm_index.search(&pattern).locate();
+            let mut positions_actual = fm_index.search(pattern).locate();
             positions_actual.sort();
 
             assert_eq!(
@@ -96,7 +96,7 @@ fn test_search_iter_matches_locate() {
                 }
             }
             let mut positions_actual = fm_index
-                .search(&pattern)
+                .search(pattern)
                 .iter_matches()
                 .map(|m| m.locate())
                 .collect::<Vec<_>>();
@@ -139,7 +139,7 @@ fn test_search_iter_matches_text_id() {
                 }
             }
             let mut text_ids_actual = fm_index
-                .search(&pattern)
+                .search(pattern)
                 .iter_matches()
                 .map(|m| m.text_id())
                 .collect::<Vec<_>>();
@@ -182,7 +182,7 @@ fn test_search_prefix_text_id() {
                 }
             }
             let mut text_ids_actual = fm_index
-                .search_prefix(&pattern)
+                .search_prefix(pattern)
                 .iter_matches()
                 .map(|m| m.text_id())
                 .collect::<Vec<_>>();
@@ -227,7 +227,7 @@ fn test_search_suffix_text_id() {
                 }
             }
             let mut text_ids_actual = fm_index
-                .search_suffix(&pattern)
+                .search_suffix(pattern)
                 .iter_matches()
                 .map(|m| m.text_id())
                 .collect::<Vec<_>>();
@@ -273,7 +273,7 @@ fn test_search_exact_text_id() {
                 }
             }
             let mut text_ids_actual = fm_index
-                .search_exact(&pattern)
+                .search_exact(pattern)
                 .iter_matches()
                 .map(|m| m.text_id())
                 .collect::<Vec<_>>();

--- a/tests/test_multitext.rs
+++ b/tests/test_multitext.rs
@@ -153,3 +153,137 @@ fn test_search_iter_matches_text_id() {
         },
     );
 }
+
+#[test]
+fn test_search_prefix_text_id() {
+    let text_size = 1024;
+
+    TestRunner {
+        texts: 100,
+        patterns: 100,
+        text_size,
+        alphabet_size: 8,
+        level_max: 3,
+        pattern_size_max: 10,
+    }
+    .run(
+        |text, level| {
+            MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), level)
+        },
+        |fm_index, text, pattern| {
+            let mut text_ids_expected = Vec::new();
+            let mut text_id = 0;
+            for i in 0..=(text_size - pattern.len()) {
+                if text[i] == 0 {
+                    text_id += 1;
+                }
+                if (i == 0 || text[i - 1] == 0) && &text[i..i + pattern.len()] == pattern {
+                    text_ids_expected.push(TextId::from(text_id));
+                }
+            }
+            let mut text_ids_actual = fm_index
+                .search_prefix(&pattern)
+                .iter_matches()
+                .map(|m| m.text_id())
+                .collect::<Vec<_>>();
+            text_ids_actual.sort();
+
+            assert_eq!(
+                text_ids_expected, text_ids_actual,
+                "text = {:?}, pattern = {:?}",
+                text, pattern
+            );
+        },
+    );
+}
+
+#[test]
+fn test_search_suffix_text_id() {
+    let text_size = 1024;
+
+    TestRunner {
+        texts: 100,
+        patterns: 100,
+        text_size,
+        alphabet_size: 8,
+        level_max: 3,
+        pattern_size_max: 10,
+    }
+    .run(
+        |text, level| {
+            MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), level)
+        },
+        |fm_index, text, pattern| {
+            let mut text_ids_expected = Vec::new();
+            let mut text_id = 0;
+            for i in 0..=(text_size - pattern.len()) {
+                if text[i] == 0 {
+                    text_id += 1;
+                }
+                if (i + pattern.len() >= text.len() || text[i + pattern.len()] == 0)
+                    && &text[i..i + pattern.len()] == pattern
+                {
+                    text_ids_expected.push(TextId::from(text_id));
+                }
+            }
+            let mut text_ids_actual = fm_index
+                .search_suffix(&pattern)
+                .iter_matches()
+                .map(|m| m.text_id())
+                .collect::<Vec<_>>();
+            text_ids_actual.sort();
+
+            assert_eq!(
+                text_ids_expected, text_ids_actual,
+                "text = {:?}, pattern = {:?}",
+                text, pattern
+            );
+        },
+    );
+}
+
+#[test]
+fn test_search_exact_text_id() {
+    let text_size = 1024;
+
+    TestRunner {
+        texts: 100,
+        patterns: 100,
+        text_size,
+        alphabet_size: 8,
+        level_max: 3,
+        pattern_size_max: 10,
+    }
+    .run(
+        |text, level| {
+            MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), level)
+        },
+        |fm_index, text, pattern| {
+            let mut text_ids_expected = Vec::new();
+            let mut text_id = 0;
+            for i in 0..=(text_size - pattern.len()) {
+                if text[i] == 0 {
+                    text_id += 1;
+                }
+                if (i == 0 || text[i - 1] == 0)
+                    && (i + pattern.len() >= text.len() || text[i + pattern.len()] == 0)
+                    && &text[i..i + pattern.len()] == pattern
+                {
+                    text_ids_expected.push(TextId::from(text_id));
+                }
+            }
+            let mut text_ids_actual = fm_index
+                .search_exact(&pattern)
+                .iter_matches()
+                .map(|m| m.text_id())
+                .collect::<Vec<_>>();
+            text_ids_actual.sort();
+
+            assert_eq!(
+                text_ids_expected, text_ids_actual,
+                "text = {:?}, pattern = {:?}",
+                text, pattern
+            );
+        },
+    );
+}

--- a/tests/testutil/mod.rs
+++ b/tests/testutil/mod.rs
@@ -43,10 +43,7 @@ impl TestRunner {
         let mut rng = StdRng::seed_from_u64(0);
 
         for _ in 0..self.texts {
-            let text = build_text(
-                || rng.gen::<u8>() % (self.alphabet_size as u8),
-                self.text_size,
-            );
+            let text = build_text(|| rng.gen::<u8>() % self.alphabet_size, self.text_size);
             let level = rng.gen::<usize>() % (self.level_max + 1);
             let fm_index = build_index(text.clone(), level);
 

--- a/tests/testutil/mod.rs
+++ b/tests/testutil/mod.rs
@@ -1,4 +1,6 @@
 use num_traits::Zero;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 
 /// Build a text for tests using a generator function `gen`.
 pub fn build_text<T: Zero + Clone, F: FnMut() -> T>(mut gen: F, len: usize) -> Vec<T> {
@@ -21,4 +23,41 @@ pub fn build_text<T: Zero + Clone, F: FnMut() -> T>(mut gen: F, len: usize) -> V
     }
 
     text
+}
+
+pub struct TestRunner {
+    pub texts: usize,
+    pub patterns: usize,
+    pub text_size: usize,
+    pub alphabet_size: u8,
+    pub level_max: usize,
+    pub pattern_size_max: usize,
+}
+
+impl TestRunner {
+    pub fn run<I, B, R>(&self, build_index: B, run_test: R)
+    where
+        B: Fn(Vec<u8>, usize) -> I,
+        R: Fn(&I, &[u8], &[u8]),
+    {
+        let mut rng = StdRng::seed_from_u64(0);
+
+        for _ in 0..self.texts {
+            let text = build_text(
+                || rng.gen::<u8>() % (self.alphabet_size as u8),
+                self.text_size,
+            );
+            let level = rng.gen::<usize>() % (self.level_max + 1);
+            let fm_index = build_index(text.clone(), level);
+
+            for _ in 0..self.patterns {
+                let pattern_size = rng.gen::<usize>() % (self.pattern_size_max - 1) + 1;
+                let pattern = (0..pattern_size)
+                    .map(|_| rng.gen::<u8>() % (self.alphabet_size - 1) + 1)
+                    .collect::<Vec<_>>();
+
+                run_test(&fm_index, &text, &pattern);
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR adds the following new APIs to `SearchIndexWithMultiTexts`.


- [x] `search_prefix`, which lists all the occurrences that match the given pattern at the text prefix. Equivalent to `starts-with` in the paper and `TextCollection::Prefix` in SXSI.
- [x] `search_suffix`, which lists all the occurrences that match the given pattern at the text suffix. Equivalent to `ends-with` in the paper and `TextCollection::Suffix` in SXSI.
- [x] `search_exact`, which lists all the texts that match the given pattern. Equivalent to `operator` in the paper and `TextCollection::Equal` in SXSI.

Resolves #68.