### PR TITLE
Turn lf_map into total function

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -12,9 +12,9 @@ pub(crate) trait SearchIndexBackend: Sized {
 
     fn get_l(&self, i: u64) -> Self::T;
 
-    fn lf_map(&self, i: u64) -> Option<u64>;
+    fn lf_map(&self, i: u64) -> u64;
 
-    fn lf_map2(&self, c: Self::T, i: u64) -> Option<u64>;
+    fn lf_map2(&self, c: Self::T, i: u64) -> u64;
 
     fn get_f(&self, i: u64) -> Self::T;
 

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -94,16 +94,16 @@ where
         Self::T::from_u64(self.bw.get_u64_unchecked(i as usize))
     }
 
-    fn lf_map(&self, i: u64) -> Option<u64> {
+    fn lf_map(&self, i: u64) -> u64 {
         let c = self.get_l(i);
         let c_count = self.cs[c.into() as usize];
         let rank = self.bw.rank_u64_unchecked(i as usize, c.into()) as u64;
-        Some(c_count + rank)
+        c_count + rank
     }
 
-    fn lf_map2(&self, c: T, i: u64) -> Option<u64> {
+    fn lf_map2(&self, c: T, i: u64) -> u64 {
         let c = self.converter.convert(c);
-        Some(self.cs[c.into() as usize] + self.bw.rank_u64_unchecked(i as usize, c.into()) as u64)
+        self.cs[c.into() as usize] + self.bw.rank_u64_unchecked(i as usize, c.into()) as u64
     }
 
     fn get_f(&self, i: u64) -> Self::T {
@@ -150,8 +150,7 @@ where
                     return (sa + steps) % self.bw.len() as u64;
                 }
                 None => {
-                    // safety: lf_map is always Some
-                    i = self.lf_map(i).unwrap();
+                    i = self.lf_map(i);
                     steps += 1;
                 }
             }
@@ -173,7 +172,7 @@ mod tests {
         });
         let mut i = 0;
         for a in ans {
-            i = fm_index.lf_map(i).unwrap();
+            i = fm_index.lf_map(i);
             assert_eq!(i, a);
         }
     }

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -137,27 +137,24 @@ where
         T::from_u64(self.s.get_u64_unchecked(self.b.rank1(i as usize + 1) - 1))
     }
 
-    fn lf_map(&self, i: u64) -> Option<u64> {
+    fn lf_map(&self, i: u64) -> u64 {
         let c = self.get_l(i);
         let j = self.b.rank1(i as usize);
         let nr = self.s.rank_u64_unchecked(j, c.into());
-        Some(
-            self.bp.select1(self.cs[c.into() as usize] as usize + nr) as u64 + i
-                - self.b.select1(j) as u64,
-        )
+
+        self.bp.select1(self.cs[c.into() as usize] as usize + nr) as u64 + i
+            - self.b.select1(j) as u64
     }
 
-    fn lf_map2(&self, c: T, i: u64) -> Option<u64> {
+    fn lf_map2(&self, c: T, i: u64) -> u64 {
         let c = self.converter.convert(c);
         let j = self.b.rank1(i as usize);
         let nr = self.s.rank_u64_unchecked(j, c.into());
         if self.get_l(i) != c {
-            Some(self.bp.select1(self.cs[c.into() as usize] as usize + nr) as u64)
+            self.bp.select1(self.cs[c.into() as usize] as usize + nr) as u64
         } else {
-            Some(
-                self.bp.select1(self.cs[c.into() as usize] as usize + nr) as u64 + i
-                    - self.b.select1(j) as u64,
-            )
+            self.bp.select1(self.cs[c.into() as usize] as usize + nr) as u64 + i
+                - self.b.select1(j) as u64
         }
     }
 
@@ -205,8 +202,7 @@ where
                     return (sa + steps) % self.len();
                 }
                 None => {
-                    // safety: lf_map is always Some
-                    i = self.lf_map(i).unwrap();
+                    i = self.lf_map(i);
                     steps += 1;
                 }
             }
@@ -301,7 +297,7 @@ mod tests {
 
         let mut i = 0;
         for a in ans {
-            let next_i = rlfmi.lf_map(i).unwrap();
+            let next_i = rlfmi.lf_map(i);
             assert_eq!(next_i, a, "should be lf_map({}) == {}", i, a);
             i = next_i;
         }
@@ -321,8 +317,8 @@ mod tests {
         let n = rlfmi.len();
 
         for (c, r) in ans {
-            let s = rlfmi.lf_map2(c, 0).unwrap();
-            let e = rlfmi.lf_map2(c, n).unwrap();
+            let s = rlfmi.lf_map2(c, 0);
+            let e = rlfmi.lf_map2(c, n);
             assert_eq!(
                 (s, e),
                 r,

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -77,14 +77,8 @@ where
         let mut e = self.e;
         let mut pattern = pattern.as_ref().to_vec();
         for &c in pattern.iter().rev() {
-            let s_mapped = self.backend.lf_map2(c, s);
-            let e_mapped = self.backend.lf_map2(c, e);
-            if let (Some(s_mapped), Some(e_mapped)) = (s_mapped, e_mapped) {
-                s = s_mapped;
-                e = e_mapped;
-            } else {
-                todo!("return a Result instead of panicking");
-            }
+            s = self.backend.lf_map2(c, s);
+            e = self.backend.lf_map2(c, e);
             if s == e {
                 break;
             }
@@ -169,7 +163,7 @@ impl<B: SearchIndexBackend> Iterator for BackwardIteratorWrapper<'_, B> {
     type Item = B::T;
     fn next(&mut self) -> Option<Self::Item> {
         let c = self.backend.get_l(self.i);
-        self.i = self.backend.lf_map(self.i)?;
+        self.i = self.backend.lf_map(self.i);
         Some(self.backend.get_converter().convert_inv(c))
     }
 }

--- a/tests/test_multitext.rs
+++ b/tests/test_multitext.rs
@@ -6,145 +6,160 @@ use fm_index::{MatchWithLocate, MatchWithTextId, MultiTextFMIndexWithLocate, Sea
 
 #[test]
 fn test_search_count() {
+    let texts = 100;
+    let patterns = 100;
     let text_size = 1024;
     let alphabet_size = 8;
-    let pattern_size_max = 128;
+    let pattern_size_max = 10;
 
     let mut rng = StdRng::seed_from_u64(0);
-    let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
-    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
+    for _ in 0..texts {
+        let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
+        let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
 
-    for i in 0..1000 {
-        let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
-        let pattern = (0..pattern_size)
-            .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
-            .collect::<Vec<_>>();
+        for i in 0..patterns {
+            let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
+            let pattern = (0..pattern_size)
+                .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
+                .collect::<Vec<_>>();
 
-        let mut count_expected = 0;
-        for i in 0..=(text_size - pattern_size) {
-            if text[i..i + pattern_size] == pattern {
-                count_expected += 1;
+            let mut count_expected = 0;
+            for i in 0..=(text_size - pattern_size) {
+                if text[i..i + pattern_size] == pattern {
+                    count_expected += 1;
+                }
             }
-        }
-        let count_actual = fm_index.search(&pattern).count();
+            let count_actual = fm_index.search(&pattern).count();
 
-        assert_eq!(
-            count_expected, count_actual,
-            "i = {:?}, text = {:?}, pattern = {:?}",
-            i, text, pattern
-        );
+            assert_eq!(
+                count_expected, count_actual,
+                "i = {:?}, text = {:?}, pattern = {:?}",
+                i, text, pattern
+            );
+        }
     }
 }
 
 #[test]
 fn test_search_locate() {
+    let texts = 100;
+    let patterns = 100;
     let text_size = 1024;
     let alphabet_size = 8;
-    let pattern_size_max = 128;
+    let pattern_size_max = 10;
 
     let mut rng = StdRng::seed_from_u64(0);
-    let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
-    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
+    for _ in 0..texts {
+        let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
+        let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
 
-    for i in 0..1000 {
-        let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
-        let pattern = (0..pattern_size)
-            .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
-            .collect::<Vec<_>>();
+        for i in 0..patterns {
+            let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
+            let pattern = (0..pattern_size)
+                .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
+                .collect::<Vec<_>>();
 
-        let mut positions_expected = Vec::new();
-        for i in 0..=(text_size - pattern_size) {
-            if text[i..i + pattern_size] == pattern {
-                positions_expected.push(i as u64);
+            let mut positions_expected = Vec::new();
+            for i in 0..=(text_size - pattern_size) {
+                if text[i..i + pattern_size] == pattern {
+                    positions_expected.push(i as u64);
+                }
             }
-        }
-        let mut positions_actual = fm_index.search(&pattern).locate();
-        positions_actual.sort();
+            let mut positions_actual = fm_index.search(&pattern).locate();
+            positions_actual.sort();
 
-        assert_eq!(
-            positions_expected, positions_actual,
-            "i = {:?}, text = {:?}, pattern = {:?}",
-            i, text, pattern
-        );
+            assert_eq!(
+                positions_expected, positions_actual,
+                "i = {:?}, text = {:?}, pattern = {:?}",
+                i, text, pattern
+            );
+        }
     }
 }
 
 #[test]
 fn test_search_iter_matches_locate() {
+    let texts = 100;
+    let patterns = 100;
     let text_size = 1024;
     let alphabet_size = 8;
-    let pattern_size_max = 128;
+    let pattern_size_max = 10;
 
     let mut rng = StdRng::seed_from_u64(0);
-    let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
 
-    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
+    for _ in 0..texts {
+        let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
+        let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
 
-    for i in 0..1000 {
-        let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
-        let pattern = (0..pattern_size)
-            .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
-            .collect::<Vec<_>>();
+        for i in 0..patterns {
+            let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
+            let pattern = (0..pattern_size)
+                .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
+                .collect::<Vec<_>>();
 
-        let mut positions_expected = Vec::new();
-        for i in 0..=(text_size - pattern_size) {
-            if text[i..i + pattern_size] == pattern {
-                positions_expected.push(i as u64);
+            let mut positions_expected = Vec::new();
+            for i in 0..=(text_size - pattern_size) {
+                if text[i..i + pattern_size] == pattern {
+                    positions_expected.push(i as u64);
+                }
             }
-        }
-        let mut positions_actual = fm_index
-            .search(&pattern)
-            .iter_matches()
-            .map(|m| m.locate())
-            .collect::<Vec<_>>();
-        positions_actual.sort();
+            let mut positions_actual = fm_index
+                .search(&pattern)
+                .iter_matches()
+                .map(|m| m.locate())
+                .collect::<Vec<_>>();
+            positions_actual.sort();
 
-        assert_eq!(
-            positions_expected, positions_actual,
-            "i = {:?}, text = {:?}, pattern = {:?}",
-            i, text, pattern
-        );
+            assert_eq!(
+                positions_expected, positions_actual,
+                "i = {:?}, text = {:?}, pattern = {:?}",
+                i, text, pattern
+            );
+        }
     }
 }
 
 #[test]
 fn test_search_iter_matches_text_id() {
+    let texts = 100;
+    let patterns = 100;
     let text_size = 1024;
     let alphabet_size = 8;
-    let pattern_size_max = 128;
+    let pattern_size_max = 10;
 
     let mut rng = StdRng::seed_from_u64(0);
-    let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
+    for _ in 0..texts {
+        let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
+        let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
 
-    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
+        for i in 0..patterns {
+            let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
+            let pattern = (0..pattern_size)
+                .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
+                .collect::<Vec<_>>();
 
-    for i in 0..1000 {
-        let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
-        let pattern = (0..pattern_size)
-            .map(|_| rng.gen::<u8>() % (alphabet_size - 1) + 1)
-            .collect::<Vec<_>>();
-
-        let mut text_ids_expected = Vec::new();
-        let mut text_id = 0;
-        for i in 0..=(text_size - pattern_size) {
-            if text[i] == 0 {
-                text_id += 1;
+            let mut text_ids_expected = Vec::new();
+            let mut text_id = 0;
+            for i in 0..=(text_size - pattern_size) {
+                if text[i] == 0 {
+                    text_id += 1;
+                }
+                if text[i..i + pattern_size] == pattern {
+                    text_ids_expected.push(TextId::from(text_id));
+                }
             }
-            if text[i..i + pattern_size] == pattern {
-                text_ids_expected.push(TextId::from(text_id));
-            }
+            let mut text_ids_actual = fm_index
+                .search(&pattern)
+                .iter_matches()
+                .map(|m| m.text_id())
+                .collect::<Vec<_>>();
+            text_ids_actual.sort();
+
+            assert_eq!(
+                text_ids_expected, text_ids_actual,
+                "i = {:?}, text = {:?}, pattern = {:?}",
+                i, text, pattern
+            );
         }
-        let mut text_ids_actual = fm_index
-            .search(&pattern)
-            .iter_matches()
-            .map(|m| m.text_id())
-            .collect::<Vec<_>>();
-        text_ids_actual.sort();
-
-        assert_eq!(
-            text_ids_expected, text_ids_actual,
-            "i = {:?}, text = {:?}, pattern = {:?}",
-            i, text, pattern
-        );
     }
 }

--- a/tests/test_multitext.rs
+++ b/tests/test_multitext.rs
@@ -12,7 +12,7 @@ fn test_search_count() {
 
     let mut rng = StdRng::seed_from_u64(0);
     let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
-    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 0);
+    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
 
     for i in 0..1000 {
         let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
@@ -44,7 +44,7 @@ fn test_search_locate() {
 
     let mut rng = StdRng::seed_from_u64(0);
     let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
-    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 0);
+    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
 
     for i in 0..1000 {
         let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
@@ -78,7 +78,7 @@ fn test_search_iter_matches_locate() {
     let mut rng = StdRng::seed_from_u64(0);
     let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
 
-    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 0);
+    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
 
     for i in 0..1000 {
         let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;
@@ -116,7 +116,7 @@ fn test_search_iter_matches_text_id() {
     let mut rng = StdRng::seed_from_u64(0);
     let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
 
-    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 0);
+    let fm_index = MultiTextFMIndexWithLocate::new(text.clone(), IdConverter::new::<u8>(), 1);
 
     for i in 0..1000 {
         let pattern_size = rng.gen::<usize>() % (pattern_size_max - 1) + 1;


### PR DESCRIPTION
This PR turns `lf_map` function into the total function, so that it can always answer a LF-mapping of given positions.

This function was made partial (i.e. returns `Optional`) when integrating multi-text FM index with SA-IS in https://github.com/ajalab/fm-index/pull/75, since it looked difficult to compute the mapping when the L character is an end-marker (`\0`). However, we found that we have to compute the LF-mapping for such characters as well to support `locate` function https://github.com/ajalab/fm-index/issues/77.

Therefore, this change introduces another approach to compute LF-mapping of each end-marker `\0` without the assumption of the ordering on the end-markers.