### PR TITLE
Rename "multi texts" to "multi docs"

### DIFF
--- a/examples/multi_docs.rs
+++ b/examples/multi_docs.rs
@@ -34,13 +34,13 @@ fn main() {
     assert_eq!(4, fm_index.search("star").count());
 
     // List the document IDs of all occurrences.
-    let mut text_ids = fm_index
+    let mut doc_ids = fm_index
         .search("How I wonder")
         .iter_matches()
-        .map(|m| m.text_id().into())
+        .map(|m| m.doc_id().into())
         .collect::<Vec<usize>>();
-    text_ids.sort();
-    assert_eq!(vec![0, 0, 1, 2], text_ids);
+    doc_ids.sort();
+    assert_eq!(vec![0, 0, 1, 2], doc_ids);
 
     // Extract preceding characters from a search position.
     let preceding_chars = fm_index
@@ -70,20 +70,20 @@ fn main() {
     );
 
     // List the IDs of texts that have the prefix.
-    let mut text_ids_with_prefix = fm_index
+    let mut doc_ids_with_prefix = fm_index
         .search_prefix("Twinkle")
         .iter_matches()
-        .map(|m| m.text_id().into())
+        .map(|m| m.doc_id().into())
         .collect::<Vec<usize>>();
-    text_ids_with_prefix.sort();
-    assert_eq!(vec![0], text_ids_with_prefix);
+    doc_ids_with_prefix.sort();
+    assert_eq!(vec![0], doc_ids_with_prefix);
 
     // List the IDs of texts that have the suffix.
-    let mut text_ids_with_suffix = fm_index
+    let mut doc_ids_with_suffix = fm_index
         .search_suffix("what you are!\n")
         .iter_matches()
-        .map(|m| m.text_id().into())
+        .map(|m| m.doc_id().into())
         .collect::<Vec<usize>>();
-    text_ids_with_suffix.sort();
-    assert_eq!(vec![0, 1, 2], text_ids_with_suffix);
+    doc_ids_with_suffix.sort();
+    assert_eq!(vec![0, 1, 2], doc_ids_with_suffix);
 }

--- a/examples/multi_docs.rs
+++ b/examples/multi_docs.rs
@@ -1,4 +1,4 @@
-use fm_index::{FMIndexMultiDocsWithLocate, Match, MatchWithTextId, Search, Text};
+use fm_index::{FMIndexMultiDocsWithLocate, Match, MatchWithDocId, Search, Text};
 
 fn main() {
     // When using FMIndexMultiDocs, the text is concatenated with an end marker \0.

--- a/examples/multi_docs.rs
+++ b/examples/multi_docs.rs
@@ -33,7 +33,7 @@ fn main() {
     // Count the number of occurrences.
     assert_eq!(4, fm_index.search("star").count());
 
-    // List the text IDs of all occurrences.
+    // List the document IDs of all occurrences.
     let mut text_ids = fm_index
         .search("How I wonder")
         .iter_matches()

--- a/examples/multi_docs.rs
+++ b/examples/multi_docs.rs
@@ -1,7 +1,7 @@
-use fm_index::{Match, MatchWithTextId, MultiTextFMIndexWithLocate, Search, Text};
+use fm_index::{FMIndexMultiDocsWithLocate, Match, MatchWithTextId, Search, Text};
 
 fn main() {
-    // When using MultiTextFMIndex, the text is concatenated with an end marker \0.
+    // When using FMIndexMultiDocs, the text is concatenated with an end marker \0.
     let text = concat!(
         // 0
         "Twinkle, twinkle, little star,\n",
@@ -28,7 +28,7 @@ fn main() {
     .as_bytes();
     let text = Text::new(text);
 
-    let fm_index = MultiTextFMIndexWithLocate::new(&text, 2);
+    let fm_index = FMIndexMultiDocsWithLocate::new(&text, 2);
 
     // Count the number of occurrences.
     assert_eq!(4, fm_index.search("star").count());

--- a/examples/multi_docs.rs
+++ b/examples/multi_docs.rs
@@ -69,7 +69,7 @@ fn main() {
         succeeding_chars,
     );
 
-    // List the IDs of texts that have the prefix.
+    // List the IDs of documents that start with a given prefix.
     let mut doc_ids_with_prefix = fm_index
         .search_prefix("Twinkle")
         .iter_matches()
@@ -78,7 +78,7 @@ fn main() {
     doc_ids_with_prefix.sort();
     assert_eq!(vec![0], doc_ids_with_prefix);
 
-    // List the IDs of texts that have the suffix.
+    // List the IDs of documents that end with a given suffix.
     let mut doc_ids_with_suffix = fm_index
         .search_suffix("what you are!\n")
         .iter_matches()

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -39,11 +39,11 @@ pub(crate) trait HasPosition {
     fn get_sa(&self, i: usize) -> usize;
 }
 
-/// A trait for an index that contains multiple texts.
-pub(crate) trait HasMultiTexts {
-    /// Returns the ID of the text that the character at the given position on the suffix array belongs to.
+/// A trait for an index that contains multiple documents.
+pub(crate) trait HasMultiDocs {
+    /// Returns the ID of the document that the character at the given position on the suffix array belongs to.
     fn doc_id(&self, i: usize) -> DocId;
 
-    /// Returns the number of texts in the index.
+    /// Returns the number of documents in the index.
     fn text_count(&self) -> usize;
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -42,7 +42,7 @@ pub(crate) trait HasPosition {
 /// A trait for an index that contains multiple texts.
 pub(crate) trait HasMultiTexts {
     /// Returns the ID of the text that the character at the given position on the suffix array belongs to.
-    fn text_id(&self, i: usize) -> DocId;
+    fn doc_id(&self, i: usize) -> DocId;
 
     /// Returns the number of texts in the index.
     fn text_count(&self) -> usize;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -45,5 +45,5 @@ pub(crate) trait HasMultiDocs {
     fn doc_id(&self, i: usize) -> DocId;
 
     /// Returns the number of documents in the index.
-    fn text_count(&self) -> usize;
+    fn docs_count(&self) -> usize;
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,5 +1,5 @@
 use crate::character::Character;
-use crate::text::TextId;
+use crate::doc::DocId;
 
 /// Trait for an FM-Index backend implementation
 pub(crate) trait SearchIndexBackend: Sized {
@@ -42,7 +42,7 @@ pub(crate) trait HasPosition {
 /// A trait for an index that contains multiple texts.
 pub(crate) trait HasMultiTexts {
     /// Returns the ID of the text that the character at the given position on the suffix array belongs to.
-    fn text_id(&self, i: usize) -> TextId;
+    fn text_id(&self, i: usize) -> DocId;
 
     /// Returns the number of texts in the index.
     fn text_count(&self) -> usize;

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -1,0 +1,15 @@
+/// A unique id identifying a single document in a text.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct DocId(usize);
+
+impl From<usize> for DocId {
+    fn from(value: usize) -> Self {
+        DocId(value)
+    }
+}
+
+impl From<DocId> for usize {
+    fn from(value: DocId) -> usize {
+        value.0
+    }
+}

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -11,11 +11,12 @@
 
 use crate::backend::HeapSize;
 use crate::character::Character;
+use crate::doc::DocId;
 use crate::fm_index::FMIndexBackend;
 use crate::multi_docs::FMIndexMultiDocsBackend;
 use crate::rlfmi::RLFMIndexBackend;
 use crate::suffix_array::sample::{self, SuffixOrderSampledArray};
-use crate::text::{Text, TextId};
+use crate::text::Text;
 use crate::wrapper::{MatchWrapper, SearchIndexWrapper, SearchWrapper};
 
 /// Trait for searching in an index.
@@ -97,9 +98,9 @@ pub trait MatchWithLocate<'a, C>: Match<'a, C> {
 }
 
 /// A match in the text that contains its text ID on the text.
-pub trait MatchWithTextId<'a, C>: Match<'a, C> {
+pub trait MatchWithDocId<'a, C>: Match<'a, C> {
     /// Get the ID of the text that the character at the matched position belongs to.
-    fn text_id(&self) -> TextId;
+    fn text_id(&self) -> DocId;
 }
 
 /// FMIndex, count only.
@@ -444,8 +445,8 @@ macro_rules! impl_match_locate {
 
 macro_rules! impl_match_text_id {
     ($t:ty) => {
-        impl<'a, C: Character> MatchWithTextId<'a, C> for $t {
-            fn text_id(&self) -> TextId {
+        impl<'a, C: Character> MatchWithDocId<'a, C> for $t {
+            fn text_id(&self) -> DocId {
                 self.0.text_id()
             }
         }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -12,7 +12,7 @@
 use crate::backend::HeapSize;
 use crate::character::Character;
 use crate::fm_index::FMIndexBackend;
-use crate::multi_text::MultiTextFMIndexBackend;
+use crate::multi_docs::FMIndexMultiDocsBackend;
 use crate::rlfmi::RLFMIndexBackend;
 use crate::suffix_array::sample::{self, SuffixOrderSampledArray};
 use crate::text::{Text, TextId};
@@ -155,30 +155,30 @@ pub struct RLFMIndexMatchWithLocate<'a, C: Character>(
 /// MultiText index, count only.
 ///
 /// This is a multi-text version of the FM-Index. It allows \0 separated strings.
-pub struct MultiTextFMIndex<C: Character>(SearchIndexWrapper<MultiTextFMIndexBackend<C, ()>>);
+pub struct FMIndexMultiDocs<C: Character>(SearchIndexWrapper<FMIndexMultiDocsBackend<C, ()>>);
 /// Search result for MultiText index, count only.
-pub struct MultiTextFMIndexSearch<'a, C: Character>(
-    SearchWrapper<'a, MultiTextFMIndexBackend<C, ()>>,
+pub struct FMIndexMultiDocsSearch<'a, C: Character>(
+    SearchWrapper<'a, FMIndexMultiDocsBackend<C, ()>>,
 );
 /// Match in the text for MultiText index.
-pub struct MultiTextFMIndexMatch<'a, C: Character>(
-    MatchWrapper<'a, MultiTextFMIndexBackend<C, ()>>,
+pub struct FMIndexMultiDocsMatch<'a, C: Character>(
+    MatchWrapper<'a, FMIndexMultiDocsBackend<C, ()>>,
 );
 
 /// MultiText index with locate support.
 ///
 /// This is a multi-text version of the FM-Index. It allows \0 separated strings.
 /// It uses additional storage to support locate queries.
-pub struct MultiTextFMIndexWithLocate<C: Character>(
-    SearchIndexWrapper<MultiTextFMIndexBackend<C, SuffixOrderSampledArray>>,
+pub struct FMIndexMultiDocsWithLocate<C: Character>(
+    SearchIndexWrapper<FMIndexMultiDocsBackend<C, SuffixOrderSampledArray>>,
 );
 /// Search result for MultiText index with locate support.
-pub struct MultiTextFMIndexSearchWithLocate<'a, C: Character>(
-    SearchWrapper<'a, MultiTextFMIndexBackend<C, SuffixOrderSampledArray>>,
+pub struct FMIndexMultiDocsSearchWithLocate<'a, C: Character>(
+    SearchWrapper<'a, FMIndexMultiDocsBackend<C, SuffixOrderSampledArray>>,
 );
 /// Match in the text for MultiText index with locate support.
-pub struct MultiTextFMIndexMatchWithLocate<'a, C: Character>(
-    MatchWrapper<'a, MultiTextFMIndexBackend<C, SuffixOrderSampledArray>>,
+pub struct FMIndexMultiDocsMatchWithLocate<'a, C: Character>(
+    MatchWrapper<'a, FMIndexMultiDocsBackend<C, SuffixOrderSampledArray>>,
 );
 
 impl<C: Character> FMIndex<C> {
@@ -225,18 +225,18 @@ impl<C: Character> RLFMIndexWithLocate<C> {
     }
 }
 
-impl<C: Character> MultiTextFMIndex<C> {
-    /// Create a new MultiTextFMIndex without locate support.
+impl<C: Character> FMIndexMultiDocs<C> {
+    /// Create a new FMIndexMultiDocs without locate support.
     pub fn new<T: AsRef<[C]>>(text: &Text<C, T>) -> Self {
-        MultiTextFMIndex(SearchIndexWrapper::new(MultiTextFMIndexBackend::new(
+        FMIndexMultiDocs(SearchIndexWrapper::new(FMIndexMultiDocsBackend::new(
             text,
             |_| (),
         )))
     }
 }
 
-impl<C: Character> MultiTextFMIndexWithLocate<C> {
-    /// Create a new MultiTextFMIndex with locate support.
+impl<C: Character> FMIndexMultiDocsWithLocate<C> {
+    /// Create a new FMIndexMultiDocs with locate support.
     ///
     /// The level argument controls the sampling rate used. Higher levels use
     /// less storage, at the cost of performance of locate queries. A level of
@@ -244,7 +244,7 @@ impl<C: Character> MultiTextFMIndexWithLocate<C> {
     /// sampled, a level of 2 means a quarter of the suffix array is sampled,
     /// and so on.
     pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Self {
-        MultiTextFMIndexWithLocate(SearchIndexWrapper::new(MultiTextFMIndexBackend::new(
+        FMIndexMultiDocsWithLocate(SearchIndexWrapper::new(FMIndexMultiDocsBackend::new(
             text,
             |sa| sample::sample(sa, level),
         )))
@@ -491,37 +491,37 @@ impl_match!(RLFMIndexMatchWithLocate<'a, C>);
 impl_match_locate!(RLFMIndexMatchWithLocate<'a, C>);
 
 impl_search_index!(
-    MultiTextFMIndex<C>,
-    MultiTextFMIndexSearch,
-    MultiTextFMIndexSearch<C>
+    FMIndexMultiDocs<C>,
+    FMIndexMultiDocsSearch,
+    FMIndexMultiDocsSearch<C>
 );
 impl_search_index_with_multi_texts!(
-    MultiTextFMIndex<C>,
-    MultiTextFMIndexSearch,
-    MultiTextFMIndexSearch<C>
+    FMIndexMultiDocs<C>,
+    FMIndexMultiDocsSearch,
+    FMIndexMultiDocsSearch<C>
 );
 impl_search!(
-    MultiTextFMIndexSearch<'a, C>,
-    MultiTextFMIndexMatch,
-    MultiTextFMIndexMatch<'a, C>
+    FMIndexMultiDocsSearch<'a, C>,
+    FMIndexMultiDocsMatch,
+    FMIndexMultiDocsMatch<'a, C>
 );
-impl_match!(MultiTextFMIndexMatch<'a, C>);
+impl_match!(FMIndexMultiDocsMatch<'a, C>);
 
 impl_search_index_with_locate!(
-    MultiTextFMIndexWithLocate<C>,
-    MultiTextFMIndexSearchWithLocate,
-    MultiTextFMIndexSearchWithLocate<C>
+    FMIndexMultiDocsWithLocate<C>,
+    FMIndexMultiDocsSearchWithLocate,
+    FMIndexMultiDocsSearchWithLocate<C>
 );
 impl_search_index_with_multi_texts!(
-    MultiTextFMIndexWithLocate<C>,
-    MultiTextFMIndexSearchWithLocate,
-    MultiTextFMIndexSearchWithLocate<C>
+    FMIndexMultiDocsWithLocate<C>,
+    FMIndexMultiDocsSearchWithLocate,
+    FMIndexMultiDocsSearchWithLocate<C>
 );
 impl_search!(
-    MultiTextFMIndexSearchWithLocate<'a, C>,
-    MultiTextFMIndexMatchWithLocate,
-    MultiTextFMIndexMatchWithLocate<'a, C>
+    FMIndexMultiDocsSearchWithLocate<'a, C>,
+    FMIndexMultiDocsMatchWithLocate,
+    FMIndexMultiDocsMatchWithLocate<'a, C>
 );
-impl_match!(MultiTextFMIndexMatchWithLocate<'a, C>);
-impl_match_locate!(MultiTextFMIndexMatchWithLocate<'a, C>);
-impl_match_text_id!(MultiTextFMIndexMatchWithLocate<'a, C>);
+impl_match!(FMIndexMultiDocsMatchWithLocate<'a, C>);
+impl_match_locate!(FMIndexMultiDocsMatchWithLocate<'a, C>);
+impl_match_text_id!(FMIndexMultiDocsMatchWithLocate<'a, C>);

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -39,7 +39,7 @@ pub trait SearchIndex<C> {
 }
 
 /// Trait for searching in an index that supports multiple texts.
-pub trait SearchIndexWithMultiTexts<C>: SearchIndex<C> {
+pub trait SearchIndexWithMultiDocs<C>: SearchIndex<C> {
     /// Search for a pattern that is a prefix of a text.
     fn search_prefix<K>(&self, pattern: K) -> impl Search<C>
     where
@@ -326,7 +326,7 @@ macro_rules! impl_search_index_with_locate {
 
 macro_rules! impl_search_index_with_multi_docs {
     ($t:ty, $s:ident, $st:ty) => {
-        impl<C: Character> SearchIndexWithMultiTexts<C> for $t {
+        impl<C: Character> SearchIndexWithMultiDocs<C> for $t {
             fn search_prefix<K>(&self, pattern: K) -> impl Search<C>
             where
                 K: AsRef<[C]>,

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -100,7 +100,7 @@ pub trait MatchWithLocate<'a, C>: Match<'a, C> {
 /// A match in the text that contains the ID of the document where the pattern is found.
 pub trait MatchWithDocId<'a, C>: Match<'a, C> {
     /// Get the ID of the text that the character at the matched position belongs to.
-    fn text_id(&self) -> DocId;
+    fn doc_id(&self) -> DocId;
 }
 
 /// FMIndex, count only.
@@ -443,11 +443,11 @@ macro_rules! impl_match_locate {
     };
 }
 
-macro_rules! impl_match_text_id {
+macro_rules! impl_match_doc_id {
     ($t:ty) => {
         impl<'a, C: Character> MatchWithDocId<'a, C> for $t {
-            fn text_id(&self) -> DocId {
-                self.0.text_id()
+            fn doc_id(&self) -> DocId {
+                self.0.doc_id()
             }
         }
     };
@@ -525,4 +525,4 @@ impl_search!(
 );
 impl_match!(FMIndexMultiDocsMatchWithLocate<'a, C>);
 impl_match_locate!(FMIndexMultiDocsMatchWithLocate<'a, C>);
-impl_match_text_id!(FMIndexMultiDocsMatchWithLocate<'a, C>);
+impl_match_doc_id!(FMIndexMultiDocsMatchWithLocate<'a, C>);

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -324,7 +324,7 @@ macro_rules! impl_search_index_with_locate {
     };
 }
 
-macro_rules! impl_search_index_with_multi_texts {
+macro_rules! impl_search_index_with_multi_docs {
     ($t:ty, $s:ident, $st:ty) => {
         impl<C: Character> SearchIndexWithMultiTexts<C> for $t {
             fn search_prefix<K>(&self, pattern: K) -> impl Search<C>
@@ -496,7 +496,7 @@ impl_search_index!(
     FMIndexMultiDocsSearch,
     FMIndexMultiDocsSearch<C>
 );
-impl_search_index_with_multi_texts!(
+impl_search_index_with_multi_docs!(
     FMIndexMultiDocs<C>,
     FMIndexMultiDocsSearch,
     FMIndexMultiDocsSearch<C>
@@ -513,7 +513,7 @@ impl_search_index_with_locate!(
     FMIndexMultiDocsSearchWithLocate,
     FMIndexMultiDocsSearchWithLocate<C>
 );
-impl_search_index_with_multi_texts!(
+impl_search_index_with_multi_docs!(
     FMIndexMultiDocsWithLocate<C>,
     FMIndexMultiDocsSearchWithLocate,
     FMIndexMultiDocsSearchWithLocate<C>

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -97,7 +97,7 @@ pub trait MatchWithLocate<'a, C>: Match<'a, C> {
     fn locate(&self) -> usize;
 }
 
-/// A match in the text that contains its text ID on the text.
+/// A match in the text that contains the ID of the document where the pattern is found.
 pub trait MatchWithDocId<'a, C>: Match<'a, C> {
     /// Get the ID of the text that the character at the matched position belongs to.
     fn text_id(&self) -> DocId;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,6 @@ pub use frontend::{
     FMIndexMultiDocsWithLocate, FMIndexSearch, FMIndexSearchWithLocate, FMIndexWithLocate, Match,
     MatchWithDocId, MatchWithLocate, RLFMIndex, RLFMIndexMatch, RLFMIndexMatchWithLocate,
     RLFMIndexSearch, RLFMIndexSearchWithLocate, RLFMIndexWithLocate, Search, SearchIndex,
-    SearchIndexWithMultiTexts, SearchWithLocate,
+    SearchIndexWithMultiDocs, SearchWithLocate,
 };
 pub use text::Text;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ mod backend;
 mod character;
 mod fm_index;
 mod frontend;
-mod multi_text;
+mod multi_docs;
 mod rlfmi;
 mod suffix_array;
 #[cfg(test)]
@@ -155,11 +155,11 @@ mod wrapper;
 pub use backend::HeapSize;
 pub use character::Character;
 pub use frontend::{
-    FMIndex, FMIndexMatch, FMIndexMatchWithLocate, FMIndexSearch, FMIndexSearchWithLocate,
-    FMIndexWithLocate, Match, MatchWithLocate, MatchWithTextId, MultiTextFMIndex,
-    MultiTextFMIndexMatch, MultiTextFMIndexMatchWithLocate, MultiTextFMIndexSearch,
-    MultiTextFMIndexSearchWithLocate, MultiTextFMIndexWithLocate, RLFMIndex, RLFMIndexMatch,
-    RLFMIndexMatchWithLocate, RLFMIndexSearch, RLFMIndexSearchWithLocate, RLFMIndexWithLocate,
-    Search, SearchIndex, SearchIndexWithMultiTexts, SearchWithLocate,
+    FMIndex, FMIndexMatch, FMIndexMatchWithLocate, FMIndexMultiDocs, FMIndexMultiDocsMatch,
+    FMIndexMultiDocsMatchWithLocate, FMIndexMultiDocsSearch, FMIndexMultiDocsSearchWithLocate,
+    FMIndexMultiDocsWithLocate, FMIndexSearch, FMIndexSearchWithLocate, FMIndexWithLocate, Match,
+    MatchWithLocate, MatchWithTextId, RLFMIndex, RLFMIndexMatch, RLFMIndexMatchWithLocate,
+    RLFMIndexSearch, RLFMIndexSearchWithLocate, RLFMIndexWithLocate, Search, SearchIndex,
+    SearchIndexWithMultiTexts, SearchWithLocate,
 };
 pub use text::{Text, TextId};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,6 +141,7 @@
 
 mod backend;
 mod character;
+mod doc;
 mod fm_index;
 mod frontend;
 mod multi_docs;
@@ -154,12 +155,13 @@ mod wrapper;
 
 pub use backend::HeapSize;
 pub use character::Character;
+pub use doc::DocId;
 pub use frontend::{
     FMIndex, FMIndexMatch, FMIndexMatchWithLocate, FMIndexMultiDocs, FMIndexMultiDocsMatch,
     FMIndexMultiDocsMatchWithLocate, FMIndexMultiDocsSearch, FMIndexMultiDocsSearchWithLocate,
     FMIndexMultiDocsWithLocate, FMIndexSearch, FMIndexSearchWithLocate, FMIndexWithLocate, Match,
-    MatchWithLocate, MatchWithTextId, RLFMIndex, RLFMIndexMatch, RLFMIndexMatchWithLocate,
+    MatchWithDocId, MatchWithLocate, RLFMIndex, RLFMIndexMatch, RLFMIndexMatchWithLocate,
     RLFMIndexSearch, RLFMIndexSearchWithLocate, RLFMIndexWithLocate, Search, SearchIndex,
     SearchIndexWithMultiTexts, SearchWithLocate,
 };
-pub use text::{Text, TextId};
+pub use text::Text;

--- a/src/multi_docs.rs
+++ b/src/multi_docs.rs
@@ -222,7 +222,7 @@ where
         }
     }
 
-    fn text_count(&self) -> usize {
+    fn docs_count(&self) -> usize {
         self.doc.len()
     }
 }

--- a/src/multi_docs.rs
+++ b/src/multi_docs.rs
@@ -290,7 +290,7 @@ mod tests {
             let text_id_actual = fm_index.text_id(i);
             assert_eq!(
                 text_id_expected, text_id_actual,
-                "the text ID of a character at position {} ({} in suffix array) must be {:?}",
+                "the doc ID of a character at position {} ({} in suffix array) must be {:?}",
                 char_pos, i, text_id_expected
             );
         }
@@ -315,7 +315,7 @@ mod tests {
                 let text_id_actual = fm_index.text_id(i);
                 assert_eq!(
                     text_id_expected, text_id_actual,
-                    "the text ID of a character at position {} ({} in suffix array) must be {:?}. text={:?}, suffix_array={:?}",
+                    "the doc ID of a character at position {} ({} in suffix array) must be {:?}. text={:?}, suffix_array={:?}",
                     char_pos, i, text_id_expected, text, suffix_array,
                 );
             }

--- a/src/multi_docs.rs
+++ b/src/multi_docs.rs
@@ -12,7 +12,7 @@ use vers_vecs::{BitVec, RsVec, WaveletMatrix};
 
 // An FM-Index supporting multiple \0 separated texts
 #[derive(Serialize, Deserialize)]
-pub struct MultiTextFMIndexBackend<C, S> {
+pub struct FMIndexMultiDocsBackend<C, S> {
     bw: WaveletMatrix,
     cs: Vec<usize>,
     suffix_array: S,
@@ -22,7 +22,7 @@ pub struct MultiTextFMIndexBackend<C, S> {
     _c: std::marker::PhantomData<C>,
 }
 
-impl<C, S> MultiTextFMIndexBackend<C, S>
+impl<C, S> FMIndexMultiDocsBackend<C, S>
 where
     C: Character,
 {
@@ -35,7 +35,7 @@ where
         let bw = Self::wavelet_matrix(text, &sa);
         let (doc, sa_idx_first_text) = Self::doc(text.text(), &bw, &sa);
 
-        MultiTextFMIndexBackend {
+        FMIndexMultiDocsBackend {
             cs,
             bw,
             suffix_array: get_sample(&sa),
@@ -91,7 +91,7 @@ where
     }
 }
 
-impl<C> HeapSize for MultiTextFMIndexBackend<C, ()>
+impl<C> HeapSize for FMIndexMultiDocsBackend<C, ()>
 where
     C: Character,
 {
@@ -100,7 +100,7 @@ where
     }
 }
 
-impl<C> HeapSize for MultiTextFMIndexBackend<C, SuffixOrderSampledArray>
+impl<C> HeapSize for FMIndexMultiDocsBackend<C, SuffixOrderSampledArray>
 where
     C: Character,
 {
@@ -112,7 +112,7 @@ where
     }
 }
 
-impl<C, S> SearchIndexBackend for MultiTextFMIndexBackend<C, S>
+impl<C, S> SearchIndexBackend for FMIndexMultiDocsBackend<C, S>
 where
     C: Character,
 {
@@ -185,7 +185,7 @@ where
     }
 }
 
-impl<C> HasPosition for MultiTextFMIndexBackend<C, SuffixOrderSampledArray>
+impl<C> HasPosition for FMIndexMultiDocsBackend<C, SuffixOrderSampledArray>
 where
     C: Character,
 {
@@ -205,7 +205,7 @@ where
     }
 }
 
-impl<C, S> HasMultiTexts for MultiTextFMIndexBackend<C, S>
+impl<C, S> HasMultiTexts for FMIndexMultiDocsBackend<C, S>
 where
     C: Character,
 {
@@ -263,7 +263,7 @@ mod tests {
             let suffix_array = testutil::build_suffix_array(&text);
             let inv_suffix_array = testutil::build_inv_suffix_array(&suffix_array);
             let fm_index =
-                MultiTextFMIndexBackend::new(&Text::new(text), |sa| sample::sample(sa, 0));
+                FMIndexMultiDocsBackend::new(&Text::new(text), |sa| sample::sample(sa, 0));
 
             let mut lf_map_expected = vec![0; text_size];
             let mut lf_map_actual = vec![0; text_size];
@@ -281,7 +281,7 @@ mod tests {
     fn test_get_text_id() {
         let text = "foo\0bar\0baz\0".as_bytes();
         let suffix_array = testutil::build_suffix_array(text);
-        let fm_index = MultiTextFMIndexBackend::new(&Text::new(text), |sa| sample::sample(sa, 0));
+        let fm_index = FMIndexMultiDocsBackend::new(&Text::new(text), |sa| sample::sample(sa, 0));
 
         for (i, &char_pos) in suffix_array.iter().enumerate() {
             let text_id_expected =
@@ -306,7 +306,7 @@ mod tests {
             let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
             let suffix_array = testutil::build_suffix_array(&text);
             let fm_index =
-                MultiTextFMIndexBackend::new(&Text::new(&text), |sa| sample::sample(sa, 0));
+                FMIndexMultiDocsBackend::new(&Text::new(&text), |sa| sample::sample(sa, 0));
 
             for (i, &char_pos) in suffix_array.iter().enumerate() {
                 let text_id_expected =

--- a/src/multi_docs.rs
+++ b/src/multi_docs.rs
@@ -1,6 +1,6 @@
 use std::ops::{Rem, Sub};
 
-use crate::backend::{HasMultiTexts, HasPosition, SearchIndexBackend};
+use crate::backend::{HasMultiDocs, HasPosition, SearchIndexBackend};
 use crate::character::Character;
 use crate::doc::DocId;
 use crate::suffix_array::sais;
@@ -206,7 +206,7 @@ where
     }
 }
 
-impl<C, S> HasMultiTexts for FMIndexMultiDocsBackend<C, S>
+impl<C, S> HasMultiDocs for FMIndexMultiDocsBackend<C, S>
 where
     C: Character,
 {

--- a/src/multi_docs.rs
+++ b/src/multi_docs.rs
@@ -2,9 +2,10 @@ use std::ops::{Rem, Sub};
 
 use crate::backend::{HasMultiTexts, HasPosition, SearchIndexBackend};
 use crate::character::Character;
+use crate::doc::DocId;
 use crate::suffix_array::sais;
 use crate::suffix_array::sample::SuffixOrderSampledArray;
-use crate::text::{Text, TextId};
+use crate::text::Text;
 use crate::HeapSize;
 
 use serde::{Deserialize, Serialize};
@@ -209,12 +210,12 @@ impl<C, S> HasMultiTexts for FMIndexMultiDocsBackend<C, S>
 where
     C: Character,
 {
-    fn text_id(&self, mut i: usize) -> TextId {
+    fn text_id(&self, mut i: usize) -> DocId {
         loop {
             if self.get_l(i).into_u64() == 0 {
                 let text_id_prev = self.doc[self.bw.rank_u64_unchecked(i, 0)];
                 let text_id = modular_add(text_id_prev, 1, self.doc.len());
-                return TextId::from(text_id);
+                return DocId::from(text_id);
             } else {
                 i = self.lf_map(i);
             }
@@ -285,7 +286,7 @@ mod tests {
 
         for (i, &char_pos) in suffix_array.iter().enumerate() {
             let text_id_expected =
-                TextId::from(text[..char_pos].iter().filter(|&&c| c == 0).count());
+                DocId::from(text[..char_pos].iter().filter(|&&c| c == 0).count());
             let text_id_actual = fm_index.text_id(i);
             assert_eq!(
                 text_id_expected, text_id_actual,
@@ -310,7 +311,7 @@ mod tests {
 
             for (i, &char_pos) in suffix_array.iter().enumerate() {
                 let text_id_expected =
-                    TextId::from(text[..(char_pos)].iter().filter(|&&c| c == 0).count());
+                    DocId::from(text[..(char_pos)].iter().filter(|&&c| c == 0).count());
                 let text_id_actual = fm_index.text_id(i);
                 assert_eq!(
                     text_id_expected, text_id_actual,

--- a/src/text.rs
+++ b/src/text.rs
@@ -2,22 +2,6 @@ use crate::util;
 use crate::Character;
 use num_traits::Bounded;
 
-/// A unique id identifying this text.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
-pub struct TextId(usize);
-
-impl From<usize> for TextId {
-    fn from(value: usize) -> Self {
-        TextId(value)
-    }
-}
-
-impl From<TextId> for usize {
-    fn from(value: TextId) -> usize {
-        value.0
-    }
-}
-
 /// A text structure used as the target for pattern searching in the index.
 ///
 /// Not only does it contain the text, but also the maximum character value in the

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -241,7 +241,7 @@ impl<B: SearchIndexBackend + HasPosition> MatchWrapper<'_, B> {
 }
 
 impl<B: SearchIndexBackend + HasMultiTexts> MatchWrapper<'_, B> {
-    pub(crate) fn text_id(&self) -> DocId {
-        self.backend.text_id(self.i)
+    pub(crate) fn doc_id(&self) -> DocId {
+        self.backend.doc_id(self.i)
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -69,7 +69,7 @@ where
     where
         K: AsRef<[B::C]>,
     {
-        SearchWrapper::new(&self.0, 0, self.0.text_count(), false).search(pattern)
+        SearchWrapper::new(&self.0, 0, self.0.docs_count(), false).search(pattern)
     }
 
     /// Search for a pattern that is an exact match of a text.
@@ -77,7 +77,7 @@ where
     where
         K: AsRef<[B::C]>,
     {
-        SearchWrapper::new(&self.0, 0, self.0.text_count(), true).search(pattern)
+        SearchWrapper::new(&self.0, 0, self.0.docs_count(), true).search(pattern)
     }
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3,7 +3,7 @@
 // This makes the implementation of the frontend more regular.
 
 use crate::backend::{HasMultiTexts, HasPosition, SearchIndexBackend};
-use crate::text::TextId;
+use crate::doc::DocId;
 use crate::{Character, HeapSize};
 
 pub(crate) struct SearchIndexWrapper<B>(B)
@@ -241,7 +241,7 @@ impl<B: SearchIndexBackend + HasPosition> MatchWrapper<'_, B> {
 }
 
 impl<B: SearchIndexBackend + HasMultiTexts> MatchWrapper<'_, B> {
-    pub(crate) fn text_id(&self) -> TextId {
+    pub(crate) fn text_id(&self) -> DocId {
         self.backend.text_id(self.i)
     }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2,7 +2,7 @@
 // the functionality used by the frontend.
 // This makes the implementation of the frontend more regular.
 
-use crate::backend::{HasMultiTexts, HasPosition, SearchIndexBackend};
+use crate::backend::{HasMultiDocs, HasPosition, SearchIndexBackend};
 use crate::doc::DocId;
 use crate::{Character, HeapSize};
 
@@ -55,7 +55,7 @@ where
 
 impl<B> SearchIndexWrapper<B>
 where
-    B: SearchIndexBackend + HasMultiTexts,
+    B: SearchIndexBackend + HasMultiDocs,
 {
     pub(crate) fn search_prefix<K>(&self, pattern: K) -> SearchWrapper<B>
     where
@@ -240,7 +240,7 @@ impl<B: SearchIndexBackend + HasPosition> MatchWrapper<'_, B> {
     }
 }
 
-impl<B: SearchIndexBackend + HasMultiTexts> MatchWrapper<'_, B> {
+impl<B: SearchIndexBackend + HasMultiDocs> MatchWrapper<'_, B> {
     pub(crate) fn doc_id(&self) -> DocId {
         self.backend.doc_id(self.i)
     }

--- a/tests/test_fmindex.rs
+++ b/tests/test_fmindex.rs
@@ -13,25 +13,22 @@ fn test_search_count() {
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
-        multi_text: false,
+        multi_docs: false,
     }
-    .run(
-        FMIndexWithLocate::new,
-        |fm_index, text, pattern| {
-            let naive_index = testutil::NaiveSearchIndex::new(text.text());
-            let matches_expected = naive_index.search(pattern);
+    .run(FMIndexWithLocate::new, |fm_index, text, pattern| {
+        let naive_index = testutil::NaiveSearchIndex::new(text.text());
+        let matches_expected = naive_index.search(pattern);
 
-            let count_expected = matches_expected.len();
-            let count_actual = fm_index.search(pattern).count();
-            assert_eq!(
-                count_expected,
-                count_actual,
-                "text = {:?}, pattern = {:?}",
-                text.text(),
-                pattern
-            );
-        },
-    );
+        let count_expected = matches_expected.len();
+        let count_actual = fm_index.search(pattern).count();
+        assert_eq!(
+            count_expected,
+            count_actual,
+            "text = {:?}, pattern = {:?}",
+            text.text(),
+            pattern
+        );
+    });
 }
 #[test]
 fn test_search_locate() {
@@ -44,31 +41,28 @@ fn test_search_locate() {
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
-        multi_text: false,
+        multi_docs: false,
     }
-    .run(
-        FMIndexWithLocate::new,
-        |fm_index, text, pattern| {
-            let naive_index = testutil::NaiveSearchIndex::new(text.text());
-            let matches_expected = naive_index.search(pattern);
+    .run(FMIndexWithLocate::new, |fm_index, text, pattern| {
+        let naive_index = testutil::NaiveSearchIndex::new(text.text());
+        let matches_expected = naive_index.search(pattern);
 
-            let positions_expected = matches_expected
-                .iter()
-                .map(|m| m.position)
-                .collect::<Vec<_>>();
-            let mut positions_actual = fm_index
-                .search(pattern)
-                .iter_matches()
-                .map(|m| m.locate())
-                .collect::<Vec<_>>();
-            positions_actual.sort();
-            assert_eq!(
-                positions_expected,
-                positions_actual,
-                "text = {:?}, pattern = {:?}",
-                text.text(),
-                pattern
-            );
-        },
-    );
+        let positions_expected = matches_expected
+            .iter()
+            .map(|m| m.position)
+            .collect::<Vec<_>>();
+        let mut positions_actual = fm_index
+            .search(pattern)
+            .iter_matches()
+            .map(|m| m.locate())
+            .collect::<Vec<_>>();
+        positions_actual.sort();
+        assert_eq!(
+            positions_expected,
+            positions_actual,
+            "text = {:?}, pattern = {:?}",
+            text.text(),
+            pattern
+        );
+    });
 }

--- a/tests/test_multi_docs.rs
+++ b/tests/test_multi_docs.rs
@@ -74,7 +74,7 @@ fn test_search_locate() {
 }
 
 #[test]
-fn test_search_text_id() {
+fn test_search_doc_id() {
     let text_size = 1024;
 
     TestRunner {
@@ -92,19 +92,19 @@ fn test_search_text_id() {
             let naive_index = testutil::NaiveSearchIndex::new(text.text());
             let matches_expected = naive_index.search(pattern);
 
-            let text_ids_expected = matches_expected
+            let doc_ids_expected = matches_expected
                 .iter()
-                .map(|m| m.text_id)
+                .map(|m| m.doc_id)
                 .collect::<Vec<_>>();
-            let mut text_ids_actual = fm_index
+            let mut doc_ids_actual = fm_index
                 .search(pattern)
                 .iter_matches()
-                .map(|m| m.text_id())
+                .map(|m| m.doc_id())
                 .collect::<Vec<_>>();
-            text_ids_actual.sort();
+            doc_ids_actual.sort();
             assert_eq!(
-                text_ids_expected,
-                text_ids_actual,
+                doc_ids_expected,
+                doc_ids_actual,
                 "text = {:?}, pattern = {:?}",
                 text.text(),
                 pattern
@@ -114,7 +114,7 @@ fn test_search_text_id() {
 }
 
 #[test]
-fn test_search_prefix_text_id() {
+fn test_search_prefix_doc_id() {
     let text_size = 1024;
 
     TestRunner {
@@ -132,19 +132,19 @@ fn test_search_prefix_text_id() {
             let naive_index = testutil::NaiveSearchIndex::new(text.text());
             let matches_expected = naive_index.search_prefix(pattern);
 
-            let text_ids_expected = matches_expected
+            let doc_ids_expected = matches_expected
                 .iter()
-                .map(|m| m.text_id)
+                .map(|m| m.doc_id)
                 .collect::<Vec<_>>();
-            let mut text_ids_actual = fm_index
+            let mut doc_ids_actual = fm_index
                 .search_prefix(pattern)
                 .iter_matches()
-                .map(|m| m.text_id())
+                .map(|m| m.doc_id())
                 .collect::<Vec<_>>();
-            text_ids_actual.sort();
+            doc_ids_actual.sort();
             assert_eq!(
-                text_ids_expected,
-                text_ids_actual,
+                doc_ids_expected,
+                doc_ids_actual,
                 "text = {:?}, pattern = {:?}",
                 text.text(),
                 pattern
@@ -154,7 +154,7 @@ fn test_search_prefix_text_id() {
 }
 
 #[test]
-fn test_search_suffix_text_id() {
+fn test_search_suffix_doc_id() {
     let text_size = 1024;
 
     TestRunner {
@@ -172,19 +172,19 @@ fn test_search_suffix_text_id() {
             let naive_index = testutil::NaiveSearchIndex::new(text.text());
             let matches_expected = naive_index.search_suffix(pattern);
 
-            let text_ids_expected = matches_expected
+            let doc_ids_expected = matches_expected
                 .iter()
-                .map(|m| m.text_id)
+                .map(|m| m.doc_id)
                 .collect::<Vec<_>>();
-            let mut text_ids_actual = fm_index
+            let mut doc_ids_actual = fm_index
                 .search_suffix(pattern)
                 .iter_matches()
-                .map(|m| m.text_id())
+                .map(|m| m.doc_id())
                 .collect::<Vec<_>>();
-            text_ids_actual.sort();
+            doc_ids_actual.sort();
             assert_eq!(
-                text_ids_expected,
-                text_ids_actual,
+                doc_ids_expected,
+                doc_ids_actual,
                 "text = {:?}, pattern = {:?}",
                 text.text(),
                 pattern
@@ -194,7 +194,7 @@ fn test_search_suffix_text_id() {
 }
 
 #[test]
-fn test_search_exact_text_id() {
+fn test_search_exact_doc_id() {
     let text_size = 1024;
 
     TestRunner {
@@ -212,19 +212,19 @@ fn test_search_exact_text_id() {
             let naive_index = testutil::NaiveSearchIndex::new(text.text());
             let matches_expected = naive_index.search_exact(pattern);
 
-            let text_ids_expected = matches_expected
+            let doc_ids_expected = matches_expected
                 .iter()
-                .map(|m| m.text_id)
+                .map(|m| m.doc_id)
                 .collect::<Vec<_>>();
-            let mut text_ids_actual = fm_index
+            let mut doc_ids_actual = fm_index
                 .search_exact(pattern)
                 .iter_matches()
-                .map(|m| m.text_id())
+                .map(|m| m.doc_id())
                 .collect::<Vec<_>>();
-            text_ids_actual.sort();
+            doc_ids_actual.sort();
             assert_eq!(
-                text_ids_expected,
-                text_ids_actual,
+                doc_ids_expected,
+                doc_ids_actual,
                 "text = {:?}, pattern = {:?}",
                 text.text(),
                 pattern

--- a/tests/test_multi_docs.rs
+++ b/tests/test_multi_docs.rs
@@ -1,5 +1,5 @@
 mod testutil;
-use fm_index::{MatchWithLocate, MatchWithTextId, MultiTextFMIndexWithLocate, Search};
+use fm_index::{FMIndexMultiDocsWithLocate, MatchWithLocate, MatchWithTextId, Search};
 use testutil::TestRunner;
 
 #[test]
@@ -16,7 +16,7 @@ fn test_search_count() {
         multi_text: true,
     }
     .run(
-        MultiTextFMIndexWithLocate::new,
+        FMIndexMultiDocsWithLocate::new,
         |fm_index, text, pattern| {
             let naive_index = testutil::NaiveSearchIndex::new(text.text());
             let matches_expected = naive_index.search(pattern);
@@ -47,7 +47,7 @@ fn test_search_locate() {
         multi_text: true,
     }
     .run(
-        MultiTextFMIndexWithLocate::new,
+        FMIndexMultiDocsWithLocate::new,
         |fm_index, text, pattern| {
             let naive_index = testutil::NaiveSearchIndex::new(text.text());
             let matches_expected = naive_index.search(pattern);
@@ -87,7 +87,7 @@ fn test_search_text_id() {
         multi_text: true,
     }
     .run(
-        MultiTextFMIndexWithLocate::new,
+        FMIndexMultiDocsWithLocate::new,
         |fm_index, text, pattern| {
             let naive_index = testutil::NaiveSearchIndex::new(text.text());
             let matches_expected = naive_index.search(pattern);
@@ -127,7 +127,7 @@ fn test_search_prefix_text_id() {
         multi_text: true,
     }
     .run(
-        MultiTextFMIndexWithLocate::new,
+        FMIndexMultiDocsWithLocate::new,
         |fm_index, text, pattern| {
             let naive_index = testutil::NaiveSearchIndex::new(text.text());
             let matches_expected = naive_index.search_prefix(pattern);
@@ -167,7 +167,7 @@ fn test_search_suffix_text_id() {
         multi_text: true,
     }
     .run(
-        MultiTextFMIndexWithLocate::new,
+        FMIndexMultiDocsWithLocate::new,
         |fm_index, text, pattern| {
             let naive_index = testutil::NaiveSearchIndex::new(text.text());
             let matches_expected = naive_index.search_suffix(pattern);
@@ -207,7 +207,7 @@ fn test_search_exact_text_id() {
         multi_text: true,
     }
     .run(
-        MultiTextFMIndexWithLocate::new,
+        FMIndexMultiDocsWithLocate::new,
         |fm_index, text, pattern| {
             let naive_index = testutil::NaiveSearchIndex::new(text.text());
             let matches_expected = naive_index.search_exact(pattern);

--- a/tests/test_multi_docs.rs
+++ b/tests/test_multi_docs.rs
@@ -13,7 +13,7 @@ fn test_search_count() {
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
-        multi_text: true,
+        multi_docs: true,
     }
     .run(
         FMIndexMultiDocsWithLocate::new,
@@ -44,7 +44,7 @@ fn test_search_locate() {
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
-        multi_text: true,
+        multi_docs: true,
     }
     .run(
         FMIndexMultiDocsWithLocate::new,
@@ -84,7 +84,7 @@ fn test_search_doc_id() {
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
-        multi_text: true,
+        multi_docs: true,
     }
     .run(
         FMIndexMultiDocsWithLocate::new,
@@ -124,7 +124,7 @@ fn test_search_prefix_doc_id() {
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
-        multi_text: true,
+        multi_docs: true,
     }
     .run(
         FMIndexMultiDocsWithLocate::new,
@@ -164,7 +164,7 @@ fn test_search_suffix_doc_id() {
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
-        multi_text: true,
+        multi_docs: true,
     }
     .run(
         FMIndexMultiDocsWithLocate::new,
@@ -204,7 +204,7 @@ fn test_search_exact_doc_id() {
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
-        multi_text: true,
+        multi_docs: true,
     }
     .run(
         FMIndexMultiDocsWithLocate::new,

--- a/tests/test_multi_docs.rs
+++ b/tests/test_multi_docs.rs
@@ -1,5 +1,5 @@
 mod testutil;
-use fm_index::{FMIndexMultiDocsWithLocate, MatchWithLocate, MatchWithTextId, Search};
+use fm_index::{FMIndexMultiDocsWithLocate, MatchWithLocate, MatchWithDocId, Search};
 use testutil::TestRunner;
 
 #[test]

--- a/tests/test_rlfmindex.rs
+++ b/tests/test_rlfmindex.rs
@@ -13,25 +13,22 @@ fn test_search_count() {
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
-        multi_text: false,
+        multi_docs: false,
     }
-    .run(
-        RLFMIndexWithLocate::new,
-        |fm_index, text, pattern| {
-            let naive_index = testutil::NaiveSearchIndex::new(text.text());
-            let matches_expected = naive_index.search(pattern);
+    .run(RLFMIndexWithLocate::new, |fm_index, text, pattern| {
+        let naive_index = testutil::NaiveSearchIndex::new(text.text());
+        let matches_expected = naive_index.search(pattern);
 
-            let count_expected = matches_expected.len();
-            let count_actual = fm_index.search(pattern).count();
-            assert_eq!(
-                count_expected,
-                count_actual,
-                "text = {:?}, pattern = {:?}",
-                text.text(),
-                pattern
-            );
-        },
-    );
+        let count_expected = matches_expected.len();
+        let count_actual = fm_index.search(pattern).count();
+        assert_eq!(
+            count_expected,
+            count_actual,
+            "text = {:?}, pattern = {:?}",
+            text.text(),
+            pattern
+        );
+    });
 }
 #[test]
 fn test_search_locate() {
@@ -44,31 +41,28 @@ fn test_search_locate() {
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
-        multi_text: false,
+        multi_docs: false,
     }
-    .run(
-        RLFMIndexWithLocate::new,
-        |fm_index, text, pattern| {
-            let naive_index = testutil::NaiveSearchIndex::new(text.text());
-            let matches_expected = naive_index.search(pattern);
+    .run(RLFMIndexWithLocate::new, |fm_index, text, pattern| {
+        let naive_index = testutil::NaiveSearchIndex::new(text.text());
+        let matches_expected = naive_index.search(pattern);
 
-            let positions_expected = matches_expected
-                .iter()
-                .map(|m| m.position)
-                .collect::<Vec<_>>();
-            let mut positions_actual = fm_index
-                .search(pattern)
-                .iter_matches()
-                .map(|m| m.locate())
-                .collect::<Vec<_>>();
-            positions_actual.sort();
-            assert_eq!(
-                positions_expected,
-                positions_actual,
-                "text = {:?}, pattern = {:?}",
-                text.text(),
-                pattern
-            );
-        },
-    );
+        let positions_expected = matches_expected
+            .iter()
+            .map(|m| m.position)
+            .collect::<Vec<_>>();
+        let mut positions_actual = fm_index
+            .search(pattern)
+            .iter_matches()
+            .map(|m| m.locate())
+            .collect::<Vec<_>>();
+        positions_actual.sort();
+        assert_eq!(
+            positions_expected,
+            positions_actual,
+            "text = {:?}, pattern = {:?}",
+            text.text(),
+            pattern
+        );
+    });
 }

--- a/tests/testutil/mod.rs
+++ b/tests/testutil/mod.rs
@@ -94,7 +94,7 @@ pub struct TestRunner {
     pub alphabet_size: u8,
     pub level_max: usize,
     pub pattern_size_max: usize,
-    pub multi_text: bool,
+    pub multi_docs: bool,
 }
 
 impl TestRunner {
@@ -106,7 +106,7 @@ impl TestRunner {
         let mut rng = StdRng::seed_from_u64(0);
 
         for _ in 0..self.texts {
-            let text = if self.multi_text {
+            let text = if self.multi_docs {
                 build_text(|| rng.gen::<u8>() % self.alphabet_size, self.text_size)
             } else {
                 build_text(|| rng.gen::<u8>() % self.alphabet_size + 1, self.text_size)

--- a/tests/testutil/mod.rs
+++ b/tests/testutil/mod.rs
@@ -1,4 +1,4 @@
-use fm_index::{Text, TextId};
+use fm_index::{DocId, Text};
 use num_traits::Zero;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -73,7 +73,7 @@ impl<'a> NaiveSearchIndex<'a> {
             {
                 result.push(NaiveSearchIndexMatch {
                     position: i,
-                    text_id: TextId::from(text_id),
+                    text_id: DocId::from(text_id),
                 });
             }
         }
@@ -84,7 +84,7 @@ impl<'a> NaiveSearchIndex<'a> {
 pub struct NaiveSearchIndexMatch {
     pub position: usize,
     #[allow(dead_code)] // false positive?
-    pub text_id: TextId,
+    pub text_id: DocId,
 }
 
 pub struct TestRunner {

--- a/tests/testutil/mod.rs
+++ b/tests/testutil/mod.rs
@@ -61,10 +61,10 @@ impl<'a> NaiveSearchIndex<'a> {
         match_suffix_only: bool,
     ) -> Vec<NaiveSearchIndexMatch> {
         let mut result = Vec::new();
-        let mut text_id = 0;
+        let mut doc_id = 0;
         for i in 0..self.text.len() - pattern.len() + 1 {
             if self.text[i] == 0 {
-                text_id += 1;
+                doc_id += 1;
             }
             if (!match_prefix_only || (i == 0 || self.text[i - 1] == 0))
                 && (!match_suffix_only
@@ -73,7 +73,7 @@ impl<'a> NaiveSearchIndex<'a> {
             {
                 result.push(NaiveSearchIndexMatch {
                     position: i,
-                    text_id: DocId::from(text_id),
+                    doc_id: DocId::from(doc_id),
                 });
             }
         }
@@ -84,7 +84,7 @@ impl<'a> NaiveSearchIndex<'a> {
 pub struct NaiveSearchIndexMatch {
     pub position: usize,
     #[allow(dead_code)] // false positive?
-    pub text_id: DocId,
+    pub doc_id: DocId,
 }
 
 pub struct TestRunner {

--- a/tests/tmp_test.rs.bak
+++ b/tests/tmp_test.rs.bak
@@ -6,7 +6,7 @@ fn tmp_lf_map() {
     let suffix_array = testutil::build_suffix_array(&text);
     let inv_suffix_array = testutil::build_inv_suffix_array(&suffix_array);
     let fm_index =
-        MultiTextFMIndexBackend::new(text.clone(), converter, |sa| sample::sample(sa, 0));
+        FMIndexMultiDocsBackend::new(text.clone(), converter, |sa| sample::sample(sa, 0));
 
     for (i, &k) in suffix_array.iter().enumerate() {
         let suffix = &text[k as usize..]


### PR DESCRIPTION
Previously, the definition of a "text" is vague.

- `Text` represents the whole search text.
- `TextId` represents an ID of the _fragment_ of a text.
- `MultiTextFMIndex` is a FM-Index variant which deals with multiple _texts_ in a single _text_.

Here we are using the term "text" in two different meanings, and this may confuse users.

Therefore, this PR enforces that we use different words for these concepts:

- A "text" refers to a whole text where we search for a text.
- A "document" (or doc in short) refers to a fragment of the text.

We rename several structs for this purpose.

- `MultiTextFMIndex` → `FMIndexMultiDocs`
- `TextId` → `DocId`