### PR TITLE
Return `Error` when failed to construct a search index

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,14 @@ let text = concat!(
     "Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
     "\0",
 ).as_bytes();
-
-// Converter converts each character into packed representation.
-// `' '` ~ `'~'` represents a range of ASCII printable characters.
-let converter = RangeConverter::new(b' ', b'~');
+let text = Text::new(text);
 
 // The sampling level determines how much is retained in order to support `locate`
 // queries. `0` retains the full information, but we don't need the whole array
 // since we can interpolate missing elements in a suffix array from others. A sampler
 // will _sieve_ a suffix array for this purpose. If you don't need `locate` queries
 // you can save the memory by not setting a sampling level.
-let index = FMIndexWithLocate::new(text, converter, 2);
+let index = FMIndexWithLocate::new(&text, 2).unwrap();
 
 // Search for a pattern string.
 let pattern = "dolor";
@@ -63,7 +60,7 @@ assert_eq!(n, 4);
 let positions = search
     .iter_matches()
     .map(|m| m.locate())
-    .collect::<Vec<u64>>();
+    .collect::<Vec<_>>();
 assert_eq!(positions, vec![246, 12, 300, 103]);
 
 // Extract preceding characters from a search position.

--- a/benches/count.rs
+++ b/benches/count.rs
@@ -8,13 +8,13 @@ mod common;
 fn prepare_fmindex(len: usize, prob: f64, m: usize) -> (impl SearchIndex<u8>, Vec<String>) {
     let text = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
-    (FMIndex::new(&text), patterns)
+    (FMIndex::new(&text).unwrap(), patterns)
 }
 
 fn prepare_rlfmindex(len: usize, prob: f64, m: usize) -> (impl SearchIndex<u8>, Vec<String>) {
     let text = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
-    (RLFMIndex::new(&text), patterns)
+    (RLFMIndex::new(&text).unwrap(), patterns)
 }
 
 pub fn bench(c: &mut Criterion) {

--- a/benches/locate.rs
+++ b/benches/locate.rs
@@ -13,7 +13,7 @@ fn prepare_fmindex(
 ) -> (FMIndexWithLocate<u8>, Vec<String>) {
     let text = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
-    (FMIndexWithLocate::new(&text, l), patterns)
+    (FMIndexWithLocate::new(&text, l).unwrap(), patterns)
 }
 
 fn prepare_rlfmindex(
@@ -24,7 +24,7 @@ fn prepare_rlfmindex(
 ) -> (RLFMIndexWithLocate<u8>, Vec<String>) {
     let text = common::binary_text_set(len, prob);
     let patterns = common::binary_patterns(m);
-    (RLFMIndexWithLocate::new(&text, l), patterns)
+    (RLFMIndexWithLocate::new(&text, l).unwrap(), patterns)
 }
 
 pub fn bench(c: &mut Criterion) {

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -16,7 +16,7 @@ fn main() {
     // since we can interpolate missing elements in a suffix array from others. A sampler
     // will _sieve_ a suffix array for this purpose. If you don't need `locate` queries
     // you can save the memory by not setting a sampling level.
-    let index = FMIndexWithLocate::new(&text, 2);
+    let index = FMIndexWithLocate::new(&text, 2).unwrap();
 
     // Search for a pattern string.
     let pattern = "dolor";

--- a/examples/multi_pieces.rs
+++ b/examples/multi_pieces.rs
@@ -28,7 +28,7 @@ fn main() {
     .as_bytes();
     let text = Text::new(text);
 
-    let fm_index = FMIndexMultiPiecesWithLocate::new(&text, 2);
+    let fm_index = FMIndexMultiPiecesWithLocate::new(&text, 2).unwrap();
 
     // Count the number of occurrences.
     assert_eq!(4, fm_index.search("star").count());

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,17 +2,13 @@
 #[derive(Debug)]
 pub enum Error {
     /// Failed to construct a suffix array from the given text.
-    SuffixArray(String),
+    InvalidText(&'static str),
 }
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::SuffixArray(msg) => write!(
-                f,
-                "failed to construct a suffix array from the given text: {}",
-                msg,
-            ),
+            Error::InvalidText(msg) => write!(f, "invalid text: {}", msg,),
         }
     }
 }
@@ -20,11 +16,5 @@ impl std::fmt::Display for Error {
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         None
-    }
-}
-
-impl From<crate::suffix_array::Error> for Error {
-    fn from(err: crate::suffix_array::Error) -> Self {
-        Error::SuffixArray(err.to_string())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,30 @@
+/// An error that can occur when constructing a search index.
+#[derive(Debug)]
+pub enum Error {
+    /// Failed to construct a suffix array from the given text.
+    SuffixArray(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::SuffixArray(msg) => write!(
+                f,
+                "failed to construct a suffix array from the given text: {}",
+                msg,
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}
+
+impl From<crate::suffix_array::Error> for Error {
+    fn from(err: crate::suffix_array::Error) -> Self {
+        Error::SuffixArray(err.to_string())
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 /// An error that can occur when constructing a search index.
 #[derive(Debug)]
 pub enum Error {
-    /// Failed to construct a suffix array from the given text.
+    /// The provided text is invalid.
     InvalidText(&'static str),
 }
 

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -29,7 +29,7 @@ where
         T: AsRef<[C]>,
     {
         let cs = sais::get_bucket_start_pos(&sais::count_chars(text));
-        let sa = sais::build_suffix_array(text).map_err(Error::from)?;
+        let sa = sais::build_suffix_array(text)?;
         let bw = Self::wavelet_matrix(text, &sa);
 
         Ok(FMIndexBackend {

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -1,5 +1,6 @@
 use crate::backend::{HasPosition, HeapSize, SearchIndexBackend};
 use crate::character::Character;
+use crate::error::Error;
 use crate::suffix_array::sais;
 use crate::suffix_array::sample::SOSampledSuffixArray;
 use crate::text::Text;
@@ -20,20 +21,23 @@ impl<C, S> FMIndexBackend<C, S>
 where
     C: Character,
 {
-    pub(crate) fn new<T>(text: &Text<C, T>, get_sample: impl Fn(&[usize]) -> S) -> Self
+    pub(crate) fn new<T>(
+        text: &Text<C, T>,
+        get_sample: impl Fn(&[usize]) -> S,
+    ) -> Result<Self, Error>
     where
         T: AsRef<[C]>,
     {
         let cs = sais::get_bucket_start_pos(&sais::count_chars(text));
-        let sa = sais::build_suffix_array(text);
+        let sa = sais::build_suffix_array(text).map_err(Error::from)?;
         let bw = Self::wavelet_matrix(text, &sa);
 
-        FMIndexBackend {
+        Ok(FMIndexBackend {
             cs,
             bw,
             suffix_array: get_sample(&sa),
             _c: std::marker::PhantomData::<C>,
-        }
+        })
     }
 
     fn wavelet_matrix<T>(text: &Text<C, T>, sa: &[usize]) -> WaveletMatrix
@@ -150,27 +154,29 @@ mod tests {
     use crate::suffix_array::sample::SOSampledSuffixArray;
 
     #[test]
-    fn test_lf_map() {
+    fn test_lf_map() -> Result<(), Error> {
         let text = "mississippi\0".as_bytes();
         let ans = vec![1, 6, 7, 2, 8, 10, 3, 9, 11, 4, 5, 0];
         let fm_index =
-            FMIndexBackend::new(&Text::new(text), |sa| SOSampledSuffixArray::sample(sa, 2));
+            FMIndexBackend::new(&Text::new(text), |sa| SOSampledSuffixArray::sample(sa, 2))?;
         let mut i = 0;
         for a in ans {
             i = fm_index.lf_map(i);
             assert_eq!(i, a);
         }
+        Ok(())
     }
 
     #[test]
-    fn test_fl_map() {
+    fn test_fl_map() -> Result<(), Error> {
         let text = "mississippi\0".as_bytes();
         let fm_index =
-            FMIndexBackend::new(&Text::new(text), |sa| SOSampledSuffixArray::sample(sa, 2));
+            FMIndexBackend::new(&Text::new(text), |sa| SOSampledSuffixArray::sample(sa, 2))?;
         let cases = vec![5usize, 0, 7, 10, 11, 4, 1, 6, 2, 3, 8, 9];
         for (i, expected) in cases.into_iter().enumerate() {
             let actual = fm_index.fl_map(i).unwrap();
             assert_eq!(actual, expected);
         }
+        Ok(())
     }
 }

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -154,29 +154,29 @@ mod tests {
     use crate::suffix_array::sample::SOSampledSuffixArray;
 
     #[test]
-    fn test_lf_map() -> Result<(), Error> {
+    fn test_lf_map() {
         let text = "mississippi\0".as_bytes();
         let ans = vec![1, 6, 7, 2, 8, 10, 3, 9, 11, 4, 5, 0];
         let fm_index =
-            FMIndexBackend::new(&Text::new(text), |sa| SOSampledSuffixArray::sample(sa, 2))?;
+            FMIndexBackend::new(&Text::new(text), |sa| SOSampledSuffixArray::sample(sa, 2))
+                .unwrap();
         let mut i = 0;
         for a in ans {
             i = fm_index.lf_map(i);
             assert_eq!(i, a);
         }
-        Ok(())
     }
 
     #[test]
-    fn test_fl_map() -> Result<(), Error> {
+    fn test_fl_map() {
         let text = "mississippi\0".as_bytes();
         let fm_index =
-            FMIndexBackend::new(&Text::new(text), |sa| SOSampledSuffixArray::sample(sa, 2))?;
+            FMIndexBackend::new(&Text::new(text), |sa| SOSampledSuffixArray::sample(sa, 2))
+                .unwrap();
         let cases = vec![5usize, 0, 7, 10, 11, 4, 1, 6, 2, 3, 8, 9];
         for (i, expected) in cases.into_iter().enumerate() {
             let actual = fm_index.fl_map(i).unwrap();
             assert_eq!(actual, expected);
         }
-        Ok(())
     }
 }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -11,6 +11,7 @@
 
 use crate::backend::HeapSize;
 use crate::character::Character;
+use crate::error::Error;
 use crate::fm_index::FMIndexBackend;
 use crate::multi_pieces::FMIndexMultiPiecesBackend;
 use crate::piece::PieceId;
@@ -184,8 +185,11 @@ pub struct FMIndexMultiPiecesMatchWithLocate<'a, C: Character>(
 
 impl<C: Character> FMIndex<C> {
     /// Create a new FMIndex without locate support.
-    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>) -> Self {
-        FMIndex(SearchIndexWrapper::new(FMIndexBackend::new(text, |_| ())))
+    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>) -> Result<Self, Error> {
+        Ok(FMIndex(SearchIndexWrapper::new(FMIndexBackend::new(
+            text,
+            |_| (),
+        )?)))
     }
 }
 
@@ -197,17 +201,20 @@ impl<C: Character> FMIndexWithLocate<C> {
     /// 0 means no sampling, and a level of 1 means half of the suffix array is
     /// sampled, a level of 2 means a quarter of the suffix array is sampled,
     /// and so on.
-    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Self {
-        FMIndexWithLocate(SearchIndexWrapper::new(FMIndexBackend::new(text, |sa| {
-            SOSampledSuffixArray::sample(sa, level)
-        })))
+    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Result<Self, Error> {
+        Ok(FMIndexWithLocate(SearchIndexWrapper::new(
+            FMIndexBackend::new(text, |sa| SOSampledSuffixArray::sample(sa, level))?,
+        )))
     }
 }
 
 impl<C: Character> RLFMIndex<C> {
     /// Create a new RLFMIndex without locate support.
-    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>) -> Self {
-        RLFMIndex(SearchIndexWrapper::new(RLFMIndexBackend::new(text, |_| ())))
+    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>) -> Result<Self, Error> {
+        Ok(RLFMIndex(SearchIndexWrapper::new(RLFMIndexBackend::new(
+            text,
+            |_| (),
+        )?)))
     }
 }
 
@@ -219,19 +226,18 @@ impl<C: Character> RLFMIndexWithLocate<C> {
     /// 0 means no sampling, and a level of 1 means half of the suffix array is
     /// sampled, a level of 2 means a quarter of the suffix array is sampled,
     /// and so on.
-    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Self {
-        RLFMIndexWithLocate(SearchIndexWrapper::new(RLFMIndexBackend::new(text, |sa| {
-            SOSampledSuffixArray::sample(sa, level)
-        })))
+    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Result<Self, Error> {
+        Ok(RLFMIndexWithLocate(SearchIndexWrapper::new(
+            RLFMIndexBackend::new(text, |sa| SOSampledSuffixArray::sample(sa, level))?,
+        )))
     }
 }
 
 impl<C: Character> FMIndexMultiPieces<C> {
     /// Create a new FMIndexMultiPieces without locate support.
-    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>) -> Self {
-        FMIndexMultiPieces(SearchIndexWrapper::new(FMIndexMultiPiecesBackend::new(
-            text,
-            |_| (),
+    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>) -> Result<Self, Error> {
+        Ok(FMIndexMultiPieces(SearchIndexWrapper::new(
+            FMIndexMultiPiecesBackend::new(text, |_| ())?,
         )))
     }
 }
@@ -244,10 +250,9 @@ impl<C: Character> FMIndexMultiPiecesWithLocate<C> {
     /// 0 means no sampling, and a level of 1 means half of the suffix array is
     /// sampled, a level of 2 means a quarter of the suffix array is sampled,
     /// and so on.
-    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Self {
-        FMIndexMultiPiecesWithLocate(SearchIndexWrapper::new(FMIndexMultiPiecesBackend::new(
-            text,
-            |sa| SOSampledSuffixArray::sample(sa, level),
+    pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Result<Self, Error> {
+        Ok(FMIndexMultiPiecesWithLocate(SearchIndexWrapper::new(
+            FMIndexMultiPiecesBackend::new(text, |sa| SOSampledSuffixArray::sample(sa, level))?,
         )))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! // since we can interpolate missing elements in a suffix array from others. A sampler
 //! // will _sieve_ a suffix array for this purpose. If you don't need `locate` queries
 //! // you can save the memory by not setting a sampling level.
-//! let index = FMIndexWithLocate::new(&text, 2);
+//! let index = FMIndexWithLocate::new(&text, 2).unwrap();
 //!
 //! // Search for a pattern string.
 //! let pattern = "dolor";
@@ -141,6 +141,7 @@
 
 mod backend;
 mod character;
+mod error;
 mod fm_index;
 mod frontend;
 mod multi_pieces;
@@ -155,6 +156,7 @@ mod wrapper;
 
 pub use backend::HeapSize;
 pub use character::Character;
+pub use error::Error;
 pub use frontend::{
     FMIndex, FMIndexMatch, FMIndexMatchWithLocate, FMIndexMultiPieces, FMIndexMultiPiecesMatch,
     FMIndexMultiPiecesMatchWithLocate, FMIndexMultiPiecesSearch,

--- a/src/multi_pieces.rs
+++ b/src/multi_pieces.rs
@@ -36,7 +36,7 @@ where
         T: AsRef<[C]>,
     {
         let cs = sais::get_bucket_start_pos(&sais::count_chars(text));
-        let sa = sais::build_suffix_array(text).map_err(Error::from)?;
+        let sa = sais::build_suffix_array(text)?;
         let bw = Self::wavelet_matrix(text, &sa);
         let (doc, sa_idx_first_text) = Self::doc(text.text(), &bw, &sa);
 

--- a/src/multi_pieces.rs
+++ b/src/multi_pieces.rs
@@ -257,7 +257,7 @@ mod tests {
     use rand::{rngs::StdRng, Rng, SeedableRng};
 
     #[test]
-    fn test_lf_map_random() -> Result<(), Error> {
+    fn test_lf_map_random() {
         let text_size = 512;
         let attempts = 100;
         let alphabet_size = 8;
@@ -269,7 +269,8 @@ mod tests {
             let inv_suffix_array = testutil::build_inv_suffix_array(&suffix_array);
             let fm_index = FMIndexMultiPiecesBackend::new(&Text::new(text), |sa| {
                 SOSampledSuffixArray::sample(sa, 0)
-            })?;
+            })
+            .unwrap();
 
             let mut lf_map_expected = vec![0; text_size];
             let mut lf_map_actual = vec![0; text_size];
@@ -281,16 +282,16 @@ mod tests {
 
             assert_eq!(lf_map_expected, lf_map_actual);
         }
-        Ok(())
     }
 
     #[test]
-    fn test_get_piece_id() -> Result<(), Error> {
+    fn test_get_piece_id() {
         let text = "foo\0bar\0baz\0".as_bytes();
         let suffix_array = testutil::build_suffix_array(text);
         let fm_index = FMIndexMultiPiecesBackend::new(&Text::new(text), |sa| {
             SOSampledSuffixArray::sample(sa, 0)
-        })?;
+        })
+        .unwrap();
 
         for (i, &char_pos) in suffix_array.iter().enumerate() {
             let piece_id_expected =
@@ -302,11 +303,10 @@ mod tests {
                 char_pos, i, piece_id_expected
             );
         }
-        Ok(())
     }
 
     #[test]
-    fn test_get_piece_id_random() -> Result<(), Error> {
+    fn test_get_piece_id_random() {
         let text_size = 512;
         let attempts = 100;
         let alphabet_size = 8;
@@ -317,7 +317,8 @@ mod tests {
             let suffix_array = testutil::build_suffix_array(&text);
             let fm_index = FMIndexMultiPiecesBackend::new(&Text::new(&text), |sa| {
                 SOSampledSuffixArray::sample(sa, 0)
-            })?;
+            })
+            .unwrap();
 
             for (i, &char_pos) in suffix_array.iter().enumerate() {
                 let piece_id_expected =
@@ -330,6 +331,5 @@ mod tests {
                 );
             }
         }
-        Ok(())
     }
 }

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -1,5 +1,6 @@
 use crate::backend::{HasPosition, HeapSize, SearchIndexBackend};
 use crate::character::Character;
+use crate::error::Error;
 use crate::suffix_array::sais;
 use crate::suffix_array::sample::SOSampledSuffixArray;
 use crate::text::Text;
@@ -25,13 +26,16 @@ impl<C, S> RLFMIndexBackend<C, S>
 where
     C: Character,
 {
-    pub(crate) fn new<T>(text: &Text<C, T>, get_sample: impl Fn(&[usize]) -> S) -> Self
+    pub(crate) fn new<T>(
+        text: &Text<C, T>,
+        get_sample: impl Fn(&[usize]) -> S,
+    ) -> Result<Self, Error>
     where
         T: AsRef<[C]>,
     {
         let n = text.text().len();
         let m = text.max_character().into_usize() + 1;
-        let sa = sais::build_suffix_array(text);
+        let sa = sais::build_suffix_array(text).map_err(Error::from)?;
 
         let mut c0 = C::from_u64(0);
         // sequence of run heads
@@ -79,7 +83,7 @@ where
 
         let b = RsVec::from_bit_vec(b);
         let bp = RsVec::from_bit_vec(bp);
-        RLFMIndexBackend {
+        Ok(RLFMIndexBackend {
             suffix_array: get_sample(&sa),
             s,
             b,
@@ -87,7 +91,7 @@ where
             cs,
             len: n,
             _c: std::marker::PhantomData::<C>,
-        }
+        })
     }
 }
 
@@ -204,7 +208,7 @@ mod tests {
     #[test]
     fn test_s() {
         let text = "mississippi\0".as_bytes();
-        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ());
+        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ()).unwrap();
         let ans = "ipsm\0pisi".as_bytes();
         for (i, a) in ans.iter().enumerate() {
             let l: u8 = rlfmi.s.get_u64_unchecked(i) as u8;
@@ -215,7 +219,7 @@ mod tests {
     #[test]
     fn test_b() {
         let text = "mississippi\0".as_bytes();
-        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ());
+        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ()).unwrap();
         let n = rlfmi.len();
         let ans = vec![1, 1, 1, 0, 1, 1, 1, 1, 1, 0, 1, 0];
         // l:      ipssm$pissii
@@ -238,7 +242,7 @@ mod tests {
     #[test]
     fn test_bp() {
         let text = "mississippi\0".as_bytes();
-        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ());
+        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ()).unwrap();
         let n = rlfmi.len();
         let ans = vec![1, 1, 1, 1, 0, 1, 1, 1, 1, 0, 1, 0];
         assert_eq!({ n }, rlfmi.bp.len());
@@ -255,7 +259,7 @@ mod tests {
     #[test]
     fn test_cs() {
         let text = "mississippi\0".as_bytes();
-        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ());
+        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ()).unwrap();
         let ans = vec![(b'\0', 0), (b'i', 1), (b'm', 4), (b'p', 5), (b's', 7)];
         for (c, a) in ans {
             assert_eq!(rlfmi.cs[c as usize], a);
@@ -265,7 +269,7 @@ mod tests {
     #[test]
     fn test_get_l() {
         let text = "mississippi\0".as_bytes();
-        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ());
+        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ()).unwrap();
         let ans = "ipssm\0pissii".to_string().into_bytes();
 
         for (i, a) in ans.into_iter().enumerate() {
@@ -278,7 +282,7 @@ mod tests {
     fn test_lf_map() {
         let text = "mississippi\0".as_bytes();
         let ans = vec![1, 6, 7, 2, 8, 10, 3, 9, 11, 4, 5, 0];
-        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ());
+        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ()).unwrap();
 
         let mut i = 0;
         for a in ans {
@@ -298,7 +302,7 @@ mod tests {
             (b'p', (6, 8)),
             (b's', (8, 12)),
         ];
-        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ());
+        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ()).unwrap();
         let n = rlfmi.len();
 
         for (c, r) in ans {
@@ -324,7 +328,7 @@ mod tests {
             ("si", (8, 10)),
             ("ssi", (10, 12)),
         ];
-        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ());
+        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ()).unwrap();
 
         let wrapper = SearchIndexWrapper::new(rlfmi);
 
@@ -338,7 +342,7 @@ mod tests {
         let text = "mississippi\0".as_bytes();
         let mut ans = text.to_vec();
         ans.sort();
-        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ());
+        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ()).unwrap();
 
         for (i, a) in ans.into_iter().enumerate() {
             let f = rlfmi.get_f(i);
@@ -349,7 +353,7 @@ mod tests {
     #[test]
     fn test_fl_map() {
         let text = "mississippi\0".as_bytes();
-        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ());
+        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ()).unwrap();
         let cases = vec![5usize, 0, 7, 10, 11, 4, 1, 6, 2, 3, 8, 9];
         for (i, expected) in cases.into_iter().enumerate() {
             let actual = rlfmi.fl_map(i).unwrap();

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -35,7 +35,7 @@ where
     {
         let n = text.text().len();
         let m = text.max_character().into_usize() + 1;
-        let sa = sais::build_suffix_array(text).map_err(Error::from)?;
+        let sa = sais::build_suffix_array(text)?;
 
         let mut c0 = C::from_u64(0);
         // sequence of run heads

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -4,3 +4,24 @@
 
 pub mod sais;
 pub mod sample;
+
+/// An error that can occur when building a suffix array.
+#[derive(Debug)]
+pub(crate) enum Error {
+    /// The given text cannot be used to build a suffix array.
+    InvalidText(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::InvalidText(msg) => write!(f, "invalid text: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        None
+    }
+}

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -4,24 +4,3 @@
 
 pub mod sais;
 pub mod sample;
-
-/// An error that can occur when building a suffix array.
-#[derive(Debug)]
-pub(crate) enum Error {
-    /// The given text cannot be used to build a suffix array.
-    InvalidText(String),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::InvalidText(msg) => write!(f, "invalid text: {}", msg),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        None
-    }
-}

--- a/src/suffix_array/sais.rs
+++ b/src/suffix_array/sais.rs
@@ -122,6 +122,12 @@ where
         0 => Ok(vec![]),
         1 => Ok(vec![0]),
         _ => {
+            let first_char = text.text()[0];
+            if first_char.into_u64() == 0 {
+                return Err(Error::InvalidText(
+                    "the given text must not start with zero character".to_string(),
+                ));
+            }
             let last_non_zero_char = text.text().iter().rposition(|&c| c.into_u64() != 0);
             if last_non_zero_char != Some(text.text().len() - 2) {
                 return Err(Error::InvalidText(
@@ -408,6 +414,15 @@ mod tests {
     }
 
     #[test]
+    fn test_error_starting_with_zero() {
+        let text = b"\0starting_with_zero\0".to_vec();
+        assert!(matches!(
+            build_suffix_array(&Text::new(text)),
+            Err(Error::InvalidText(_))
+        ));
+    }
+
+    #[test]
     fn test_length_1() {
         let text = &[0u8];
         let sa_actual = build_suffix_array(&Text::new(text)).unwrap();
@@ -434,15 +449,6 @@ mod tests {
     #[test]
     fn test_nulls() {
         let text = b"mm\0ii\0s\0sii\0ssii\0ppii\0".to_vec();
-        let sa_actual = build_suffix_array(&Text::new(&text)).unwrap();
-        let sa_expected = build_expected_suffix_array(text);
-        assert_eq!(sa_actual, sa_expected);
-    }
-
-    #[test]
-    #[ignore]
-    fn test_starting_with_zero() {
-        let text = b"\0\0mm\0\0ii\0s\0\0\0sii\0ssii\0ppii\0".to_vec();
         let sa_actual = build_suffix_array(&Text::new(&text)).unwrap();
         let sa_expected = build_expected_suffix_array(text);
         assert_eq!(sa_actual, sa_expected);

--- a/src/suffix_array/sais.rs
+++ b/src/suffix_array/sais.rs
@@ -3,7 +3,7 @@
 //!    IEEE Transactions on Computers, 60(10), 1471–1484. <https://doi.org/10.1109/tc.2010.188>
 use vers_vecs::BitVec;
 
-use crate::suffix_array::Error;
+use crate::error::Error;
 use crate::{text::Text, Character};
 
 pub fn count_chars<C, T>(text: &Text<C, T>) -> Vec<usize>
@@ -128,13 +128,13 @@ where
     let first_char = text.text()[0];
     if first_char.into_u64() == 0 {
         return Err(Error::InvalidText(
-            "the given text must not start with zero character".to_string(),
+            "the given text must not start with zero character",
         ));
     }
     let last_non_zero_char = text.text().iter().rposition(|&c| c.into_u64() != 0);
     if last_non_zero_char != Some(text.text().len() - 2) {
         return Err(Error::InvalidText(
-            "the given text must end with exactly one zero character".to_string(),
+            "the given text must end with exactly one zero character",
         ));
     }
 

--- a/src/suffix_array/sais.rs
+++ b/src/suffix_array/sais.rs
@@ -3,6 +3,7 @@
 //!    IEEE Transactions on Computers, 60(10), 1471–1484. <https://doi.org/10.1109/tc.2010.188>
 use vers_vecs::BitVec;
 
+use crate::suffix_array::Error;
 use crate::{text::Text, Character};
 
 pub fn count_chars<C, T>(text: &Text<C, T>) -> Vec<usize>
@@ -111,24 +112,25 @@ where
 }
 
 /// Build a suffix array from the given [`text`] using SA-IS algorithm.
-pub fn build_suffix_array<C, T>(text: &Text<C, T>) -> Vec<usize>
+pub fn build_suffix_array<C, T>(text: &Text<C, T>) -> Result<Vec<usize>, Error>
 where
     C: Character,
     T: AsRef<[C]>,
 {
     let n = text.text().len();
     match n {
-        0 => vec![],
-        1 => vec![0],
+        0 => Ok(vec![]),
+        1 => Ok(vec![0]),
         _ => {
-            debug_assert_eq!(
-                text.text().iter().rposition(|&c| c.into_u64() != 0),
-                Some(text.text().len() - 2),
-                "the given text must end with a single 0.",
-            );
+            let last_non_zero_char = text.text().iter().rposition(|&c| c.into_u64() != 0);
+            if last_non_zero_char != Some(text.text().len() - 2) {
+                return Err(Error::InvalidText(
+                    "the given text must end with exactly one zero character".to_string(),
+                ));
+            }
             let mut sa = vec![usize::MAX; n];
             sais_sub(text, &mut sa);
-            sa
+            Ok(sa)
         }
     }
 }
@@ -388,30 +390,27 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_panic_no_trailing_zero() {
+    fn test_error_no_trailing_zero() {
         let text = "nozero".to_string().into_bytes();
-        build_suffix_array(&Text::new(text));
+        assert!(matches!(
+            build_suffix_array(&Text::new(text)),
+            Err(Error::InvalidText(_))
+        ));
     }
 
     #[test]
-    #[should_panic]
-    fn test_panic_too_many_trailing_zero() {
+    fn test_error_too_many_trailing_zero() {
         let text = "toomanyzeros\0\0".to_string().into_bytes();
-        build_suffix_array(&Text::new(text));
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_panic_consecutive_nulls() {
-        let text = b"mm\0\0ii\0s\0\0\0sii\0ssii\0ppii\0".to_vec();
-        build_suffix_array(&Text::new(text));
+        assert!(matches!(
+            build_suffix_array(&Text::new(text)),
+            Err(Error::InvalidText(_))
+        ));
     }
 
     #[test]
     fn test_length_1() {
         let text = &[0u8];
-        let sa_actual = build_suffix_array(&Text::new(text));
+        let sa_actual = build_suffix_array(&Text::new(text)).unwrap();
         let sa_expected = build_expected_suffix_array(text);
         assert_eq!(sa_actual, sa_expected);
     }
@@ -419,7 +418,7 @@ mod tests {
     #[test]
     fn test_length_2() {
         let text = &[3u8, 0];
-        let sa_actual = build_suffix_array(&Text::new(text));
+        let sa_actual = build_suffix_array(&Text::new(text)).unwrap();
         let sa_expected = build_expected_suffix_array(text);
         assert_eq!(sa_actual, sa_expected);
     }
@@ -427,7 +426,7 @@ mod tests {
     #[test]
     fn test_length_4() {
         let text = &[3u8, 2, 1, 0];
-        let sa_actual = build_suffix_array(&Text::new(text));
+        let sa_actual = build_suffix_array(&Text::new(text)).unwrap();
         let sa_expected = build_expected_suffix_array(text);
         assert_eq!(sa_actual, sa_expected);
     }
@@ -435,7 +434,7 @@ mod tests {
     #[test]
     fn test_nulls() {
         let text = b"mm\0ii\0s\0sii\0ssii\0ppii\0".to_vec();
-        let sa_actual = build_suffix_array(&Text::new(&text));
+        let sa_actual = build_suffix_array(&Text::new(&text)).unwrap();
         let sa_expected = build_expected_suffix_array(text);
         assert_eq!(sa_actual, sa_expected);
     }
@@ -444,7 +443,7 @@ mod tests {
     #[ignore]
     fn test_starting_with_zero() {
         let text = b"\0\0mm\0\0ii\0s\0\0\0sii\0ssii\0ppii\0".to_vec();
-        let sa_actual = build_suffix_array(&Text::new(&text));
+        let sa_actual = build_suffix_array(&Text::new(&text)).unwrap();
         let sa_expected = build_expected_suffix_array(text);
         assert_eq!(sa_actual, sa_expected);
     }
@@ -453,7 +452,7 @@ mod tests {
     fn test_small() {
         let mut text = "mmiissiissiippii".to_string().into_bytes();
         text.push(0);
-        let sa_actual = build_suffix_array(&Text::new(&text));
+        let sa_actual = build_suffix_array(&Text::new(&text)).unwrap();
         let sa_expected = build_expected_suffix_array(&text);
         assert_eq!(sa_actual, sa_expected, "text: {:?}", text);
     }
@@ -465,7 +464,7 @@ mod tests {
 
         for _ in 0..1000 {
             let text = build_text(|| rng.gen::<u8>() % (b'z' - b'a') + b'a', len);
-            let sa_actual = build_suffix_array(&Text::new(&text));
+            let sa_actual = build_suffix_array(&Text::new(&text)).unwrap();
             let sa_expected = build_expected_suffix_array(&text);
             assert_eq!(sa_actual, sa_expected, "text: {:?}", text);
         }
@@ -479,7 +478,7 @@ mod tests {
 
         for _ in 0..1000 {
             let text = build_text(|| if rng.gen_bool(prob) { b'a' } else { b'b' }, len);
-            let sa_actual = build_suffix_array(&Text::new(&text));
+            let sa_actual = build_suffix_array(&Text::new(&text)).unwrap();
             let sa_expected = build_expected_suffix_array(&text);
             assert_eq!(sa_actual, sa_expected, "text: {:?}", text);
         }
@@ -492,7 +491,7 @@ mod tests {
 
         for _ in 0..1000 {
             let text = build_text(|| rng.gen::<u8>() % 2, len);
-            let sa_actual = build_suffix_array(&Text::new(&text));
+            let sa_actual = build_suffix_array(&Text::new(&text)).unwrap();
             let sa_expected = build_expected_suffix_array(&text);
             assert_eq!(sa_actual, sa_expected, "text: {:?}", text);
         }
@@ -505,7 +504,7 @@ mod tests {
 
         for _ in 0..1000 {
             let text = build_text(|| rng.gen::<u8>(), len);
-            let sa_actual = build_suffix_array(&Text::new(&text));
+            let sa_actual = build_suffix_array(&Text::new(&text)).unwrap();
             let sa_expected = build_expected_suffix_array(&text);
             assert_eq!(sa_actual, sa_expected, "text: {:?}", text);
         }

--- a/src/suffix_array/sais.rs
+++ b/src/suffix_array/sais.rs
@@ -118,27 +118,29 @@ where
     T: AsRef<[C]>,
 {
     let n = text.text().len();
-    match n {
-        0 => Ok(vec![]),
-        1 => Ok(vec![0]),
-        _ => {
-            let first_char = text.text()[0];
-            if first_char.into_u64() == 0 {
-                return Err(Error::InvalidText(
-                    "the given text must not start with zero character".to_string(),
-                ));
-            }
-            let last_non_zero_char = text.text().iter().rposition(|&c| c.into_u64() != 0);
-            if last_non_zero_char != Some(text.text().len() - 2) {
-                return Err(Error::InvalidText(
-                    "the given text must end with exactly one zero character".to_string(),
-                ));
-            }
-            let mut sa = vec![usize::MAX; n];
-            sais_sub(text, &mut sa);
-            Ok(sa)
-        }
+    if n == 0 {
+        return Ok(vec![]);
     }
+    if n == 1 {
+        return Ok(vec![0]);
+    }
+
+    let first_char = text.text()[0];
+    if first_char.into_u64() == 0 {
+        return Err(Error::InvalidText(
+            "the given text must not start with zero character".to_string(),
+        ));
+    }
+    let last_non_zero_char = text.text().iter().rposition(|&c| c.into_u64() != 0);
+    if last_non_zero_char != Some(text.text().len() - 2) {
+        return Err(Error::InvalidText(
+            "the given text must end with exactly one zero character".to_string(),
+        ));
+    }
+
+    let mut sa = vec![usize::MAX; n];
+    sais_sub(text, &mut sa);
+    Ok(sa)
 }
 
 #[allow(clippy::cognitive_complexity)]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -14,7 +14,7 @@ fn size<T: HeapSize>(t: &T) -> usize {
 
 #[test]
 fn test_fm_index_backend_trait_fm_index_suffix_array() {
-    let index = FMIndexWithLocate::new(&Text::new("text\0".as_bytes()), 2);
+    let index = FMIndexWithLocate::new(&Text::new("text\0".as_bytes()), 2).unwrap();
 
     // any result will do for this test
     assert_eq!(len(&index), 5);
@@ -22,7 +22,7 @@ fn test_fm_index_backend_trait_fm_index_suffix_array() {
 
 #[test]
 fn test_heap_size_trait_fm_index_suffix_array() {
-    let index = FMIndexWithLocate::new(&Text::new("text\0".as_bytes()), 2);
+    let index = FMIndexWithLocate::new(&Text::new("text\0".as_bytes()), 2).unwrap();
 
     // any result will do for this test
     assert!(size(&index) > 0);
@@ -30,7 +30,7 @@ fn test_heap_size_trait_fm_index_suffix_array() {
 
 #[test]
 fn test_fm_index_backend_trait_fm_index_count_only() {
-    let index = FMIndex::new(&Text::new("text\0".as_bytes()));
+    let index = FMIndex::new(&Text::new("text\0".as_bytes())).unwrap();
 
     // any result will do for this test
     assert_eq!(len(&index), 5);
@@ -38,7 +38,7 @@ fn test_fm_index_backend_trait_fm_index_count_only() {
 
 #[test]
 fn test_heap_size_trait_fm_index_count_only() {
-    let index = FMIndex::new(&Text::new("text\0".as_bytes()));
+    let index = FMIndex::new(&Text::new("text\0".as_bytes())).unwrap();
 
     // any result will do for this test
     assert!(size(&index) > 0);
@@ -46,7 +46,7 @@ fn test_heap_size_trait_fm_index_count_only() {
 
 #[test]
 fn test_fm_index_backend_trait_rlfm_index_suffix_array() {
-    let index = RLFMIndexWithLocate::new(&Text::new("text\0".as_bytes()), 2);
+    let index = RLFMIndexWithLocate::new(&Text::new("text\0".as_bytes()), 2).unwrap();
 
     // any result will do for this test
     assert_eq!(len(&index), 5);
@@ -54,7 +54,7 @@ fn test_fm_index_backend_trait_rlfm_index_suffix_array() {
 
 #[test]
 fn test_heap_size_trait_rlfm_index_suffix_array() {
-    let index = RLFMIndexWithLocate::new(&Text::new("text\0".as_bytes()), 2);
+    let index = RLFMIndexWithLocate::new(&Text::new("text\0".as_bytes()), 2).unwrap();
 
     // any result will do for this test
     assert!(size(&index) > 0);
@@ -62,7 +62,7 @@ fn test_heap_size_trait_rlfm_index_suffix_array() {
 
 #[test]
 fn test_fm_index_backend_trait_rlfm_index_count_only() {
-    let index = RLFMIndex::new(&Text::new("text\0".as_bytes()));
+    let index = RLFMIndex::new(&Text::new("text\0".as_bytes())).unwrap();
 
     // any result will do for this test
     assert_eq!(len(&index), 5);
@@ -70,7 +70,7 @@ fn test_fm_index_backend_trait_rlfm_index_count_only() {
 
 #[test]
 fn test_heap_size_trait_rlfm_index_count_only() {
-    let index = RLFMIndex::new(&Text::new("text\0".as_bytes()));
+    let index = RLFMIndex::new(&Text::new("text\0".as_bytes())).unwrap();
 
     // any result will do for this test
     assert!(size(&index) > 0);

--- a/tests/test_fmindex.rs
+++ b/tests/test_fmindex.rs
@@ -5,7 +5,7 @@ use testutil::TestRunner;
 #[test]
 fn test_small_search_count() {
     let text = Text::new("a\0".as_bytes());
-    let fm_index = FMIndexWithLocate::new(&text, 2);
+    let fm_index = FMIndexWithLocate::new(&text, 2).unwrap();
 
     assert_eq!(1, fm_index.search("a").count());
 }
@@ -13,7 +13,7 @@ fn test_small_search_count() {
 #[test]
 fn test_small_search_locate() {
     let text = Text::new("a\0".as_bytes());
-    let fm_index = FMIndexWithLocate::new(&text, 2);
+    let fm_index = FMIndexWithLocate::new(&text, 2).unwrap();
 
     let positions = fm_index
         .search("a")

--- a/tests/test_multi_pieces.rs
+++ b/tests/test_multi_pieces.rs
@@ -7,7 +7,7 @@ use testutil::TestRunner;
 #[test]
 fn test_small_search_count() {
     let text = Text::new("a\0".as_bytes());
-    let fm_index = FMIndexMultiPiecesWithLocate::new(&text, 2);
+    let fm_index = FMIndexMultiPiecesWithLocate::new(&text, 2).unwrap();
 
     assert_eq!(1, fm_index.search("a").count());
 }
@@ -15,7 +15,7 @@ fn test_small_search_count() {
 #[test]
 fn test_small_search_locate() {
     let text = Text::new("a\0".as_bytes());
-    let fm_index = FMIndexMultiPiecesWithLocate::new(&text, 2);
+    let fm_index = FMIndexMultiPiecesWithLocate::new(&text, 2).unwrap();
 
     let positions = fm_index
         .search("a")
@@ -29,7 +29,7 @@ fn test_small_search_locate() {
 #[test]
 fn test_small_search_piece_id() {
     let text = Text::new("a\0".as_bytes());
-    let fm_index = FMIndexMultiPiecesWithLocate::new(&text, 2);
+    let fm_index = FMIndexMultiPiecesWithLocate::new(&text, 2).unwrap();
 
     let positions = fm_index
         .search("a")

--- a/tests/test_rlfmindex.rs
+++ b/tests/test_rlfmindex.rs
@@ -5,7 +5,7 @@ use testutil::TestRunner;
 #[test]
 fn test_small_search_count() {
     let text = Text::new("a\0".as_bytes());
-    let fm_index = RLFMIndexWithLocate::new(&text, 2);
+    let fm_index = RLFMIndexWithLocate::new(&text, 2).unwrap();
 
     assert_eq!(1, fm_index.search("a").count());
 }
@@ -13,7 +13,7 @@ fn test_small_search_count() {
 #[test]
 fn test_small_search_locate() {
     let text = Text::new("a\0".as_bytes());
-    let fm_index = RLFMIndexWithLocate::new(&text, 2);
+    let fm_index = RLFMIndexWithLocate::new(&text, 2).unwrap();
 
     let positions = fm_index
         .search("a")

--- a/tests/testutil/mod.rs
+++ b/tests/testutil/mod.rs
@@ -1,4 +1,4 @@
-use fm_index::{PieceId, Text};
+use fm_index::{Error, PieceId, Text};
 use num_traits::Zero;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -102,7 +102,7 @@ pub struct TestRunner {
 impl TestRunner {
     pub fn run<I, B, R>(&self, build_index: B, run_test: R)
     where
-        B: Fn(&Text<u8, Vec<u8>>, usize) -> I,
+        B: Fn(&Text<u8, Vec<u8>>, usize) -> Result<I, Error>,
         R: Fn(&I, &Text<u8, Vec<u8>>, &[u8]),
     {
         let mut rng = StdRng::seed_from_u64(0);
@@ -116,7 +116,7 @@ impl TestRunner {
             };
             let text = Text::new(text);
             let level = rng.gen::<usize>() % (self.level_max + 1);
-            let fm_index = build_index(&text, level);
+            let fm_index = build_index(&text, level).unwrap();
 
             for _ in 0..self.patterns {
                 let pattern_size_max = if self.pattern_size_max > text_size {


### PR DESCRIPTION
Resolves #72.

This PR updates `suffix_array::sais::build_suffix_array` and `new` methods to return `Result` when it received a text that can't be recognized by the current suffix array construction algorithm.

