### PR TITLE
Fix SA sampling to support small texts

### DIFF
--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -1,7 +1,7 @@
 use crate::backend::{HasPosition, HeapSize, SearchIndexBackend};
 use crate::character::Character;
 use crate::suffix_array::sais;
-use crate::suffix_array::sample::SuffixOrderSampledArray;
+use crate::suffix_array::sample::SOSampledSuffixArray;
 use crate::text::Text;
 
 use serde::{Deserialize, Serialize};
@@ -62,7 +62,7 @@ where
     }
 }
 
-impl<C> HeapSize for FMIndexBackend<C, SuffixOrderSampledArray>
+impl<C> HeapSize for FMIndexBackend<C, SOSampledSuffixArray>
 where
     C: Character,
 {
@@ -124,7 +124,7 @@ where
     }
 }
 
-impl<C> HasPosition for FMIndexBackend<C, SuffixOrderSampledArray>
+impl<C> HasPosition for FMIndexBackend<C, SOSampledSuffixArray>
 where
     C: Character,
 {
@@ -147,15 +147,14 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::suffix_array::sample::SuffixOrderSampledArray;
+    use crate::suffix_array::sample::SOSampledSuffixArray;
 
     #[test]
     fn test_lf_map() {
         let text = "mississippi\0".as_bytes();
         let ans = vec![1, 6, 7, 2, 8, 10, 3, 9, 11, 4, 5, 0];
-        let fm_index = FMIndexBackend::new(&Text::new(text), |sa| {
-            SuffixOrderSampledArray::sample(sa, 2)
-        });
+        let fm_index =
+            FMIndexBackend::new(&Text::new(text), |sa| SOSampledSuffixArray::sample(sa, 2));
         let mut i = 0;
         for a in ans {
             i = fm_index.lf_map(i);
@@ -166,9 +165,8 @@ mod tests {
     #[test]
     fn test_fl_map() {
         let text = "mississippi\0".as_bytes();
-        let fm_index = FMIndexBackend::new(&Text::new(text), |sa| {
-            SuffixOrderSampledArray::sample(sa, 2)
-        });
+        let fm_index =
+            FMIndexBackend::new(&Text::new(text), |sa| SOSampledSuffixArray::sample(sa, 2));
         let cases = vec![5usize, 0, 7, 10, 11, 4, 1, 6, 2, 3, 8, 9];
         for (i, expected) in cases.into_iter().enumerate() {
             let actual = fm_index.fl_map(i).unwrap();

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -147,13 +147,15 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::suffix_array::sample;
+    use crate::suffix_array::sample::SuffixOrderSampledArray;
 
     #[test]
     fn test_lf_map() {
         let text = "mississippi\0".as_bytes();
         let ans = vec![1, 6, 7, 2, 8, 10, 3, 9, 11, 4, 5, 0];
-        let fm_index = FMIndexBackend::new(&Text::new(text), |sa| sample::sample(sa, 2));
+        let fm_index = FMIndexBackend::new(&Text::new(text), |sa| {
+            SuffixOrderSampledArray::sample(sa, 2)
+        });
         let mut i = 0;
         for a in ans {
             i = fm_index.lf_map(i);
@@ -164,7 +166,9 @@ mod tests {
     #[test]
     fn test_fl_map() {
         let text = "mississippi\0".as_bytes();
-        let fm_index = FMIndexBackend::new(&Text::new(text), |sa| sample::sample(sa, 2));
+        let fm_index = FMIndexBackend::new(&Text::new(text), |sa| {
+            SuffixOrderSampledArray::sample(sa, 2)
+        });
         let cases = vec![5usize, 0, 7, 10, 11, 4, 1, 6, 2, 3, 8, 9];
         for (i, expected) in cases.into_iter().enumerate() {
             let actual = fm_index.fl_map(i).unwrap();

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -15,7 +15,7 @@ use crate::fm_index::FMIndexBackend;
 use crate::multi_pieces::FMIndexMultiPiecesBackend;
 use crate::piece::PieceId;
 use crate::rlfmi::RLFMIndexBackend;
-use crate::suffix_array::sample::{self, SuffixOrderSampledArray};
+use crate::suffix_array::sample::SuffixOrderSampledArray;
 use crate::text::Text;
 use crate::wrapper::{MatchWrapper, SearchIndexWrapper, SearchWrapper};
 
@@ -199,7 +199,7 @@ impl<C: Character> FMIndexWithLocate<C> {
     /// and so on.
     pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Self {
         FMIndexWithLocate(SearchIndexWrapper::new(FMIndexBackend::new(text, |sa| {
-            sample::sample(sa, level)
+            SuffixOrderSampledArray::sample(sa, level)
         })))
     }
 }
@@ -221,7 +221,7 @@ impl<C: Character> RLFMIndexWithLocate<C> {
     /// and so on.
     pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Self {
         RLFMIndexWithLocate(SearchIndexWrapper::new(RLFMIndexBackend::new(text, |sa| {
-            sample::sample(sa, level)
+            SuffixOrderSampledArray::sample(sa, level)
         })))
     }
 }
@@ -247,7 +247,7 @@ impl<C: Character> FMIndexMultiPiecesWithLocate<C> {
     pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Self {
         FMIndexMultiPiecesWithLocate(SearchIndexWrapper::new(FMIndexMultiPiecesBackend::new(
             text,
-            |sa| sample::sample(sa, level),
+            |sa| SuffixOrderSampledArray::sample(sa, level),
         )))
     }
 }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -15,7 +15,7 @@ use crate::fm_index::FMIndexBackend;
 use crate::multi_pieces::FMIndexMultiPiecesBackend;
 use crate::piece::PieceId;
 use crate::rlfmi::RLFMIndexBackend;
-use crate::suffix_array::sample::SuffixOrderSampledArray;
+use crate::suffix_array::sample::SOSampledSuffixArray;
 use crate::text::Text;
 use crate::wrapper::{MatchWrapper, SearchIndexWrapper, SearchWrapper};
 
@@ -117,15 +117,15 @@ pub struct FMIndexMatch<'a, C: Character>(MatchWrapper<'a, FMIndexBackend<C, ()>
 ///
 /// This is an FM-Index which uses additional storage to support locate queries.
 pub struct FMIndexWithLocate<C: Character>(
-    SearchIndexWrapper<FMIndexBackend<C, SuffixOrderSampledArray>>,
+    SearchIndexWrapper<FMIndexBackend<C, SOSampledSuffixArray>>,
 );
 /// Search result for FMIndex with locate support.
 pub struct FMIndexSearchWithLocate<'a, C: Character>(
-    SearchWrapper<'a, FMIndexBackend<C, SuffixOrderSampledArray>>,
+    SearchWrapper<'a, FMIndexBackend<C, SOSampledSuffixArray>>,
 );
 /// Match in the text for FMIndex with locate support.
 pub struct FMIndexMatchWithLocate<'a, C: Character>(
-    MatchWrapper<'a, FMIndexBackend<C, SuffixOrderSampledArray>>,
+    MatchWrapper<'a, FMIndexBackend<C, SOSampledSuffixArray>>,
 );
 
 /// RLFMIndex, count only.
@@ -142,15 +142,15 @@ pub struct RLFMIndexMatch<'a, C: Character>(MatchWrapper<'a, RLFMIndexBackend<C,
 /// This is a version of the FM-Index that uses less space, but is also less efficient.
 /// It uses additional storage to support locate queries.
 pub struct RLFMIndexWithLocate<C: Character>(
-    SearchIndexWrapper<RLFMIndexBackend<C, SuffixOrderSampledArray>>,
+    SearchIndexWrapper<RLFMIndexBackend<C, SOSampledSuffixArray>>,
 );
 /// Search result for RLFMIndex with locate support.
 pub struct RLFMIndexSearchWithLocate<'a, C: Character>(
-    SearchWrapper<'a, RLFMIndexBackend<C, SuffixOrderSampledArray>>,
+    SearchWrapper<'a, RLFMIndexBackend<C, SOSampledSuffixArray>>,
 );
 /// Match in the text for RLFMIndex with locate support.
 pub struct RLFMIndexMatchWithLocate<'a, C: Character>(
-    MatchWrapper<'a, RLFMIndexBackend<C, SuffixOrderSampledArray>>,
+    MatchWrapper<'a, RLFMIndexBackend<C, SOSampledSuffixArray>>,
 );
 
 /// MultiText index, count only.
@@ -171,15 +171,15 @@ pub struct FMIndexMultiPiecesMatch<'a, C: Character>(
 /// This is a multi-text version of the FM-Index. It allows \0 separated strings.
 /// It uses additional storage to support locate queries.
 pub struct FMIndexMultiPiecesWithLocate<C: Character>(
-    SearchIndexWrapper<FMIndexMultiPiecesBackend<C, SuffixOrderSampledArray>>,
+    SearchIndexWrapper<FMIndexMultiPiecesBackend<C, SOSampledSuffixArray>>,
 );
 /// Search result for MultiText index with locate support.
 pub struct FMIndexMultiPiecesSearchWithLocate<'a, C: Character>(
-    SearchWrapper<'a, FMIndexMultiPiecesBackend<C, SuffixOrderSampledArray>>,
+    SearchWrapper<'a, FMIndexMultiPiecesBackend<C, SOSampledSuffixArray>>,
 );
 /// Match in the text for MultiText index with locate support.
 pub struct FMIndexMultiPiecesMatchWithLocate<'a, C: Character>(
-    MatchWrapper<'a, FMIndexMultiPiecesBackend<C, SuffixOrderSampledArray>>,
+    MatchWrapper<'a, FMIndexMultiPiecesBackend<C, SOSampledSuffixArray>>,
 );
 
 impl<C: Character> FMIndex<C> {
@@ -199,7 +199,7 @@ impl<C: Character> FMIndexWithLocate<C> {
     /// and so on.
     pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Self {
         FMIndexWithLocate(SearchIndexWrapper::new(FMIndexBackend::new(text, |sa| {
-            SuffixOrderSampledArray::sample(sa, level)
+            SOSampledSuffixArray::sample(sa, level)
         })))
     }
 }
@@ -221,7 +221,7 @@ impl<C: Character> RLFMIndexWithLocate<C> {
     /// and so on.
     pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Self {
         RLFMIndexWithLocate(SearchIndexWrapper::new(RLFMIndexBackend::new(text, |sa| {
-            SuffixOrderSampledArray::sample(sa, level)
+            SOSampledSuffixArray::sample(sa, level)
         })))
     }
 }
@@ -247,7 +247,7 @@ impl<C: Character> FMIndexMultiPiecesWithLocate<C> {
     pub fn new<T: AsRef<[C]>>(text: &Text<C, T>, level: usize) -> Self {
         FMIndexMultiPiecesWithLocate(SearchIndexWrapper::new(FMIndexMultiPiecesBackend::new(
             text,
-            |sa| SuffixOrderSampledArray::sample(sa, level),
+            |sa| SOSampledSuffixArray::sample(sa, level),
         )))
     }
 }

--- a/src/multi_pieces.rs
+++ b/src/multi_pieces.rs
@@ -248,7 +248,7 @@ fn modular_sub<T: Sub<Output = T> + Ord + num_traits::Zero>(a: T, b: T, m: T) ->
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::suffix_array::sample;
+    use crate::suffix_array::sample::SuffixOrderSampledArray;
     use crate::testutil;
     use rand::{rngs::StdRng, Rng, SeedableRng};
 
@@ -263,8 +263,9 @@ mod tests {
             let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
             let suffix_array = testutil::build_suffix_array(&text);
             let inv_suffix_array = testutil::build_inv_suffix_array(&suffix_array);
-            let fm_index =
-                FMIndexMultiPiecesBackend::new(&Text::new(text), |sa| sample::sample(sa, 0));
+            let fm_index = FMIndexMultiPiecesBackend::new(&Text::new(text), |sa| {
+                SuffixOrderSampledArray::sample(sa, 0)
+            });
 
             let mut lf_map_expected = vec![0; text_size];
             let mut lf_map_actual = vec![0; text_size];
@@ -282,7 +283,9 @@ mod tests {
     fn test_get_piece_id() {
         let text = "foo\0bar\0baz\0".as_bytes();
         let suffix_array = testutil::build_suffix_array(text);
-        let fm_index = FMIndexMultiPiecesBackend::new(&Text::new(text), |sa| sample::sample(sa, 0));
+        let fm_index = FMIndexMultiPiecesBackend::new(&Text::new(text), |sa| {
+            SuffixOrderSampledArray::sample(sa, 0)
+        });
 
         for (i, &char_pos) in suffix_array.iter().enumerate() {
             let piece_id_expected =
@@ -306,8 +309,9 @@ mod tests {
         for _ in 0..attempts {
             let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
             let suffix_array = testutil::build_suffix_array(&text);
-            let fm_index =
-                FMIndexMultiPiecesBackend::new(&Text::new(&text), |sa| sample::sample(sa, 0));
+            let fm_index = FMIndexMultiPiecesBackend::new(&Text::new(&text), |sa| {
+                SuffixOrderSampledArray::sample(sa, 0)
+            });
 
             for (i, &char_pos) in suffix_array.iter().enumerate() {
                 let piece_id_expected =

--- a/src/multi_pieces.rs
+++ b/src/multi_pieces.rs
@@ -4,7 +4,7 @@ use crate::backend::{HasMultiPieces, HasPosition, SearchIndexBackend};
 use crate::character::Character;
 use crate::piece::PieceId;
 use crate::suffix_array::sais;
-use crate::suffix_array::sample::SuffixOrderSampledArray;
+use crate::suffix_array::sample::SOSampledSuffixArray;
 use crate::text::Text;
 use crate::HeapSize;
 
@@ -101,7 +101,7 @@ where
     }
 }
 
-impl<C> HeapSize for FMIndexMultiPiecesBackend<C, SuffixOrderSampledArray>
+impl<C> HeapSize for FMIndexMultiPiecesBackend<C, SOSampledSuffixArray>
 where
     C: Character,
 {
@@ -186,7 +186,7 @@ where
     }
 }
 
-impl<C> HasPosition for FMIndexMultiPiecesBackend<C, SuffixOrderSampledArray>
+impl<C> HasPosition for FMIndexMultiPiecesBackend<C, SOSampledSuffixArray>
 where
     C: Character,
 {
@@ -248,7 +248,7 @@ fn modular_sub<T: Sub<Output = T> + Ord + num_traits::Zero>(a: T, b: T, m: T) ->
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::suffix_array::sample::SuffixOrderSampledArray;
+    use crate::suffix_array::sample::SOSampledSuffixArray;
     use crate::testutil;
     use rand::{rngs::StdRng, Rng, SeedableRng};
 
@@ -264,7 +264,7 @@ mod tests {
             let suffix_array = testutil::build_suffix_array(&text);
             let inv_suffix_array = testutil::build_inv_suffix_array(&suffix_array);
             let fm_index = FMIndexMultiPiecesBackend::new(&Text::new(text), |sa| {
-                SuffixOrderSampledArray::sample(sa, 0)
+                SOSampledSuffixArray::sample(sa, 0)
             });
 
             let mut lf_map_expected = vec![0; text_size];
@@ -284,7 +284,7 @@ mod tests {
         let text = "foo\0bar\0baz\0".as_bytes();
         let suffix_array = testutil::build_suffix_array(text);
         let fm_index = FMIndexMultiPiecesBackend::new(&Text::new(text), |sa| {
-            SuffixOrderSampledArray::sample(sa, 0)
+            SOSampledSuffixArray::sample(sa, 0)
         });
 
         for (i, &char_pos) in suffix_array.iter().enumerate() {
@@ -310,7 +310,7 @@ mod tests {
             let text = testutil::build_text(|| rng.gen::<u8>() % alphabet_size, text_size);
             let suffix_array = testutil::build_suffix_array(&text);
             let fm_index = FMIndexMultiPiecesBackend::new(&Text::new(&text), |sa| {
-                SuffixOrderSampledArray::sample(sa, 0)
+                SOSampledSuffixArray::sample(sa, 0)
             });
 
             for (i, &char_pos) in suffix_array.iter().enumerate() {

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -1,7 +1,7 @@
 use crate::backend::{HasPosition, HeapSize, SearchIndexBackend};
 use crate::character::Character;
 use crate::suffix_array::sais;
-use crate::suffix_array::sample::SuffixOrderSampledArray;
+use crate::suffix_array::sample::SOSampledSuffixArray;
 use crate::text::Text;
 
 use serde::{Deserialize, Serialize};
@@ -103,7 +103,7 @@ where
     }
 }
 
-impl<C> HeapSize for RLFMIndexBackend<C, SuffixOrderSampledArray>
+impl<C> HeapSize for RLFMIndexBackend<C, SOSampledSuffixArray>
 where
     C: Character,
 {
@@ -176,7 +176,7 @@ where
     }
 }
 
-impl<C> HasPosition for RLFMIndexBackend<C, SuffixOrderSampledArray>
+impl<C> HasPosition for RLFMIndexBackend<C, SOSampledSuffixArray>
 where
     C: Character,
 {

--- a/src/suffix_array/sample.rs
+++ b/src/suffix_array/sample.rs
@@ -21,7 +21,7 @@ impl SuffixOrderSampledArray {
         }
 
         let n = sa.len();
-        let word_size = (util::log2_usize(n) + 1) as usize;
+        let word_size = util::log2_usize(n) + 1;
         if n <= 1 << level {
             // If the sampling level is too high, we don't sample the suffix array at all.
             level = 0;
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn test_empty() {
-        let ssa = SuffixOrderSampledArray::sample(&vec![], 2);
+        let ssa = SuffixOrderSampledArray::sample(&[], 2);
         assert_eq!(ssa.get(0), None);
     }
 

--- a/src/suffix_array/sample.rs
+++ b/src/suffix_array/sample.rs
@@ -66,7 +66,6 @@ pub(crate) fn sample(sa: &[usize], mut level: usize) -> SuffixOrderSampledArray 
 
     let sa_samples_len = ((n - 1) >> level) + 1;
     let mut sa_samples = BitVec::with_capacity(sa_samples_len);
-    // fid::BitArray::with_word_size(word_size, sa_samples_len);
     for i in 0..sa_samples_len {
         sa_samples.append_bits(sa[i << level] as u64, word_size);
     }

--- a/src/suffix_array/sample.rs
+++ b/src/suffix_array/sample.rs
@@ -16,7 +16,10 @@ pub struct SuffixOrderSampledArray {
 
 impl SuffixOrderSampledArray {
     pub(crate) fn get(&self, i: usize) -> Option<usize> {
-        debug_assert!(i < self.len);
+        if i >= self.len {
+            return None;
+        }
+
         if i & ((1 << self.level) - 1) == 0 {
             Some(
                 self.sa
@@ -57,6 +60,10 @@ impl Default for SuffixOrderSampledArray {
 }
 
 pub(crate) fn sample(sa: &[usize], mut level: usize) -> SuffixOrderSampledArray {
+    if sa.is_empty() {
+        return SuffixOrderSampledArray::default();
+    }
+
     let n = sa.len();
     let word_size = (util::log2_usize(n) + 1) as usize;
     if n <= 1 << level {
@@ -80,6 +87,12 @@ pub(crate) fn sample(sa: &[usize], mut level: usize) -> SuffixOrderSampledArray 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_empty() {
+        let ssa = sample(&vec![], 2);
+        assert_eq!(ssa.get(0), None);
+    }
 
     #[test]
     fn test_regular() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,3 @@
-pub fn log2(x: u64) -> u64 {
-    ((std::mem::size_of::<u64>() * 8) as u64) - u64::from(x.leading_zeros()) - 1
-}
-
 pub fn log2_usize(x: usize) -> usize {
     (std::mem::size_of::<usize>() * 8) - (x.leading_zeros() as usize) - 1
 }
@@ -9,16 +5,6 @@ pub fn log2_usize(x: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[test]
-    fn test_log2() {
-        assert_eq!(log2(2u64), 1);
-        assert_eq!(log2(3u64), 1);
-        assert_eq!(log2(4u64), 2);
-        assert_eq!(log2(5u64), 2);
-        assert_eq!(log2(6u64), 2);
-        assert_eq!(log2(7u64), 2);
-        assert_eq!(log2(8u64), 3);
-    }
 
     #[test]
     fn test_log2_usize() {

--- a/tests/test_fmindex.rs
+++ b/tests/test_fmindex.rs
@@ -4,12 +4,12 @@ use testutil::TestRunner;
 
 #[test]
 fn test_search_count() {
-    let text_size = 1024;
+    let text_size_max = 1024;
 
     TestRunner {
         texts: 100,
         patterns: 100,
-        text_size,
+        text_size_max,
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
@@ -32,12 +32,12 @@ fn test_search_count() {
 }
 #[test]
 fn test_search_locate() {
-    let text_size = 100;
+    let text_size_max = 100;
 
     TestRunner {
         texts: 100,
         patterns: 100,
-        text_size,
+        text_size_max,
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,

--- a/tests/test_fmindex.rs
+++ b/tests/test_fmindex.rs
@@ -1,9 +1,30 @@
 mod testutil;
-use fm_index::{FMIndexWithLocate, MatchWithLocate, Search};
+use fm_index::{FMIndexWithLocate, MatchWithLocate, Search, Text};
 use testutil::TestRunner;
 
 #[test]
-fn test_search_count() {
+fn test_small_search_count() {
+    let text = Text::new("a\0".as_bytes());
+    let fm_index = FMIndexWithLocate::new(&text, 2);
+
+    assert_eq!(1, fm_index.search("a").count());
+}
+
+#[test]
+fn test_small_search_locate() {
+    let text = Text::new("a\0".as_bytes());
+    let fm_index = FMIndexWithLocate::new(&text, 2);
+
+    let positions = fm_index
+        .search("a")
+        .iter_matches()
+        .map(|m| m.locate())
+        .collect::<Vec<_>>();
+    assert_eq!(vec![0], positions);
+}
+
+#[test]
+fn test_random_search_count() {
     let text_size_max = 1024;
 
     TestRunner {
@@ -31,7 +52,7 @@ fn test_search_count() {
     });
 }
 #[test]
-fn test_search_locate() {
+fn test_random_search_locate() {
     let text_size_max = 100;
 
     TestRunner {

--- a/tests/test_multi_pieces.rs
+++ b/tests/test_multi_pieces.rs
@@ -1,9 +1,47 @@
 mod testutil;
-use fm_index::{FMIndexMultiPiecesWithLocate, MatchWithLocate, MatchWithPieceId, Search};
+use fm_index::{
+    FMIndexMultiPiecesWithLocate, MatchWithLocate, MatchWithPieceId, PieceId, Search, Text,
+};
 use testutil::TestRunner;
 
 #[test]
-fn test_search_count() {
+fn test_small_search_count() {
+    let text = Text::new("a\0".as_bytes());
+    let fm_index = FMIndexMultiPiecesWithLocate::new(&text, 2);
+
+    assert_eq!(1, fm_index.search("a").count());
+}
+
+#[test]
+fn test_small_search_locate() {
+    let text = Text::new("a\0".as_bytes());
+    let fm_index = FMIndexMultiPiecesWithLocate::new(&text, 2);
+
+    let positions = fm_index
+        .search("a")
+        .iter_matches()
+        .map(|m| m.locate())
+        .collect::<Vec<_>>();
+
+    assert_eq!(vec![0], positions);
+}
+
+#[test]
+fn test_small_search_piece_id() {
+    let text = Text::new("a\0".as_bytes());
+    let fm_index = FMIndexMultiPiecesWithLocate::new(&text, 2);
+
+    let positions = fm_index
+        .search("a")
+        .iter_matches()
+        .map(|m| m.piece_id())
+        .collect::<Vec<_>>();
+
+    assert_eq!(vec![PieceId::from(0)], positions);
+}
+
+#[test]
+fn test_random_search_count() {
     let text_size_max = 1024;
 
     TestRunner {
@@ -34,7 +72,7 @@ fn test_search_count() {
     );
 }
 #[test]
-fn test_search_locate() {
+fn test_random_search_locate() {
     let text_size_max = 1024;
 
     TestRunner {
@@ -74,7 +112,7 @@ fn test_search_locate() {
 }
 
 #[test]
-fn test_search_piece_id() {
+fn test_random_search_piece_id() {
     let text_size_max = 1024;
 
     TestRunner {
@@ -114,7 +152,7 @@ fn test_search_piece_id() {
 }
 
 #[test]
-fn test_search_prefix_piece_id() {
+fn test_random_search_prefix_piece_id() {
     let text_size_max = 1024;
 
     TestRunner {
@@ -154,7 +192,7 @@ fn test_search_prefix_piece_id() {
 }
 
 #[test]
-fn test_search_suffix_piece_id() {
+fn test_random_search_suffix_piece_id() {
     let text_size_max = 1024;
 
     TestRunner {
@@ -194,7 +232,7 @@ fn test_search_suffix_piece_id() {
 }
 
 #[test]
-fn test_search_exact_piece_id() {
+fn test_random_search_exact_piece_id() {
     let text_size_max = 1024;
 
     TestRunner {

--- a/tests/test_multi_pieces.rs
+++ b/tests/test_multi_pieces.rs
@@ -4,12 +4,12 @@ use testutil::TestRunner;
 
 #[test]
 fn test_search_count() {
-    let text_size = 1024;
+    let text_size_max = 1024;
 
     TestRunner {
         texts: 100,
         patterns: 100,
-        text_size,
+        text_size_max,
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
@@ -35,12 +35,12 @@ fn test_search_count() {
 }
 #[test]
 fn test_search_locate() {
-    let text_size = 1024;
+    let text_size_max = 1024;
 
     TestRunner {
         texts: 100,
         patterns: 100,
-        text_size,
+        text_size_max,
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
@@ -75,12 +75,12 @@ fn test_search_locate() {
 
 #[test]
 fn test_search_piece_id() {
-    let text_size = 1024;
+    let text_size_max = 1024;
 
     TestRunner {
         texts: 100,
         patterns: 100,
-        text_size,
+        text_size_max,
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
@@ -115,12 +115,12 @@ fn test_search_piece_id() {
 
 #[test]
 fn test_search_prefix_piece_id() {
-    let text_size = 1024;
+    let text_size_max = 1024;
 
     TestRunner {
         texts: 100,
         patterns: 100,
-        text_size,
+        text_size_max,
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
@@ -155,12 +155,12 @@ fn test_search_prefix_piece_id() {
 
 #[test]
 fn test_search_suffix_piece_id() {
-    let text_size = 1024;
+    let text_size_max = 1024;
 
     TestRunner {
         texts: 100,
         patterns: 100,
-        text_size,
+        text_size_max,
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
@@ -195,12 +195,12 @@ fn test_search_suffix_piece_id() {
 
 #[test]
 fn test_search_exact_piece_id() {
-    let text_size = 1024;
+    let text_size_max = 1024;
 
     TestRunner {
         texts: 100,
         patterns: 100,
-        text_size,
+        text_size_max,
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,

--- a/tests/test_rlfmindex.rs
+++ b/tests/test_rlfmindex.rs
@@ -4,12 +4,12 @@ use testutil::TestRunner;
 
 #[test]
 fn test_search_count() {
-    let text_size = 1024;
+    let text_size_max = 1024;
 
     TestRunner {
         texts: 100,
         patterns: 100,
-        text_size,
+        text_size_max,
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,
@@ -32,12 +32,12 @@ fn test_search_count() {
 }
 #[test]
 fn test_search_locate() {
-    let text_size = 100;
+    let text_size_max = 100;
 
     TestRunner {
         texts: 100,
         patterns: 100,
-        text_size,
+        text_size_max,
         alphabet_size: 8,
         level_max: 3,
         pattern_size_max: 10,

--- a/tests/test_rlfmindex.rs
+++ b/tests/test_rlfmindex.rs
@@ -1,9 +1,30 @@
 mod testutil;
-use fm_index::{MatchWithLocate, RLFMIndexWithLocate, Search};
+use fm_index::{MatchWithLocate, RLFMIndexWithLocate, Search, Text};
 use testutil::TestRunner;
 
 #[test]
-fn test_search_count() {
+fn test_small_search_count() {
+    let text = Text::new("a\0".as_bytes());
+    let fm_index = RLFMIndexWithLocate::new(&text, 2);
+
+    assert_eq!(1, fm_index.search("a").count());
+}
+
+#[test]
+fn test_small_search_locate() {
+    let text = Text::new("a\0".as_bytes());
+    let fm_index = RLFMIndexWithLocate::new(&text, 2);
+
+    let positions = fm_index
+        .search("a")
+        .iter_matches()
+        .map(|m| m.locate())
+        .collect::<Vec<_>>();
+    assert_eq!(vec![0], positions);
+}
+
+#[test]
+fn test_random_search_count() {
     let text_size_max = 1024;
 
     TestRunner {
@@ -31,7 +52,7 @@ fn test_search_count() {
     });
 }
 #[test]
-fn test_search_locate() {
+fn test_random_search_locate() {
     let text_size_max = 100;
 
     TestRunner {


### PR DESCRIPTION
To reduce the memory space, we _sample_ the suffix array of the text. For instance, if the sampling level (`level`) is 2, the sampled suffix array stores the elements at 0, 4, 8, ... of the original suffix array.

As reported in #23, however, this sampling implementation has an issue when the given text is too small compared with the sampling level, such as the text is of length 1 while the sampling level is 2.

This PR fixes it by giving up sampling the array when the text is small compared with the level.

----

Breaking changes:

- `SuffixOrderSampledArray` is renamed to `SOSampledSuffixArray`, to clarify that the data structure represents a suffix array. The term "suffix order" (taken from [SDSL](https://github.com/simongog/sdsl-lite/blob/c32874cb2d8524119f25f3b501526fe692df29f4/include/sdsl/csa_sampling_strategy.hpp#L45)) is shortened to "SO" for simplicity.