### PR TITLE
Refactor heap size

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -25,15 +25,6 @@ pub(crate) trait SearchIndexBackend: Sized {
     fn len(&self) -> usize;
 }
 
-/// Access the heap size of the structure.
-///
-/// This can be useful if you want to fine-tune the memory usage of your
-/// application.
-pub trait HeapSize {
-    /// The size on the heap of this structure, in bytes.
-    fn heap_size(&self) -> usize;
-}
-
 /// A trait for an index that supports locate queries.
 pub(crate) trait HasPosition {
     fn get_sa(&self, i: usize) -> usize;

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -1,6 +1,7 @@
-use crate::backend::{HasPosition, HeapSize, SearchIndexBackend};
+use crate::backend::{HasPosition, SearchIndexBackend};
 use crate::character::Character;
 use crate::error::Error;
+use crate::heap_size::HeapSize;
 use crate::suffix_array::sais;
 use crate::suffix_array::sample::SOSampledSuffixArray;
 use crate::text::Text;

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -57,23 +57,14 @@ where
     }
 }
 
-impl<C> HeapSize for FMIndexBackend<C, ()>
+impl<C, S> HeapSize for FMIndexBackend<C, S>
 where
-    C: Character,
-{
-    fn heap_size(&self) -> usize {
-        self.bw.heap_size() + self.cs.capacity() * std::mem::size_of::<u64>()
-    }
-}
-
-impl<C> HeapSize for FMIndexBackend<C, SOSampledSuffixArray>
-where
-    C: Character,
+    S: HeapSize,
 {
     fn heap_size(&self) -> usize {
         self.bw.heap_size()
             + self.cs.capacity() * std::mem::size_of::<u64>()
-            + self.suffix_array.size()
+            + self.suffix_array.heap_size()
     }
 }
 

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -64,7 +64,7 @@ where
 {
     fn heap_size(&self) -> usize {
         self.bw.heap_size()
-            + self.cs.len() * std::mem::size_of::<u64>()
+            + self.cs.len() * std::mem::size_of::<usize>()
             + self.suffix_array.heap_size()
     }
 }

--- a/src/fm_index.rs
+++ b/src/fm_index.rs
@@ -64,7 +64,7 @@ where
 {
     fn heap_size(&self) -> usize {
         self.bw.heap_size()
-            + self.cs.capacity() * std::mem::size_of::<u64>()
+            + self.cs.len() * std::mem::size_of::<u64>()
             + self.suffix_array.heap_size()
     }
 }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -16,6 +16,7 @@ use crate::fm_index::FMIndexBackend;
 use crate::multi_pieces::FMIndexMultiPiecesBackend;
 use crate::piece::PieceId;
 use crate::rlfmi::RLFMIndexBackend;
+use crate::suffix_array::discard::DiscardedSuffixArray;
 use crate::suffix_array::sample::SOSampledSuffixArray;
 use crate::text::Text;
 use crate::wrapper::{MatchWrapper, SearchIndexWrapper, SearchWrapper};
@@ -102,11 +103,15 @@ pub trait MatchWithPieceId<'a, C>: Match<'a, C> {
 ///
 /// The FM-Index is both a search index as well as compact representation of
 /// the text.
-pub struct FMIndex<C: Character>(SearchIndexWrapper<FMIndexBackend<C, ()>>);
+pub struct FMIndex<C: Character>(SearchIndexWrapper<FMIndexBackend<C, DiscardedSuffixArray>>);
 /// Search result for FMIndex, count only.
-pub struct FMIndexSearch<'a, C: Character>(SearchWrapper<'a, FMIndexBackend<C, ()>>);
+pub struct FMIndexSearch<'a, C: Character>(
+    SearchWrapper<'a, FMIndexBackend<C, DiscardedSuffixArray>>,
+);
 /// Match in the text for FMIndex.
-pub struct FMIndexMatch<'a, C: Character>(MatchWrapper<'a, FMIndexBackend<C, ()>>);
+pub struct FMIndexMatch<'a, C: Character>(
+    MatchWrapper<'a, FMIndexBackend<C, DiscardedSuffixArray>>,
+);
 
 /// FMIndex with locate support.
 ///
@@ -126,11 +131,15 @@ pub struct FMIndexMatchWithLocate<'a, C: Character>(
 /// RLFMIndex, count only.
 ///
 /// This is a version of the FM-Index that uses less space, but is also less efficient.
-pub struct RLFMIndex<C: Character>(SearchIndexWrapper<RLFMIndexBackend<C, ()>>);
+pub struct RLFMIndex<C: Character>(SearchIndexWrapper<RLFMIndexBackend<C, DiscardedSuffixArray>>);
 /// Search result for RLFMIndex, count only.
-pub struct RLFMIndexSearch<'a, C: Character>(SearchWrapper<'a, RLFMIndexBackend<C, ()>>);
+pub struct RLFMIndexSearch<'a, C: Character>(
+    SearchWrapper<'a, RLFMIndexBackend<C, DiscardedSuffixArray>>,
+);
 /// Match in the text for RLFMIndex.
-pub struct RLFMIndexMatch<'a, C: Character>(MatchWrapper<'a, RLFMIndexBackend<C, ()>>);
+pub struct RLFMIndexMatch<'a, C: Character>(
+    MatchWrapper<'a, RLFMIndexBackend<C, DiscardedSuffixArray>>,
+);
 
 /// RLFMIndex with locate support.
 ///
@@ -151,14 +160,16 @@ pub struct RLFMIndexMatchWithLocate<'a, C: Character>(
 /// MultiText index, count only.
 ///
 /// This is a multi-text version of the FM-Index. It allows \0 separated strings.
-pub struct FMIndexMultiPieces<C: Character>(SearchIndexWrapper<FMIndexMultiPiecesBackend<C, ()>>);
+pub struct FMIndexMultiPieces<C: Character>(
+    SearchIndexWrapper<FMIndexMultiPiecesBackend<C, DiscardedSuffixArray>>,
+);
 /// Search result for MultiText index, count only.
 pub struct FMIndexMultiPiecesSearch<'a, C: Character>(
-    SearchWrapper<'a, FMIndexMultiPiecesBackend<C, ()>>,
+    SearchWrapper<'a, FMIndexMultiPiecesBackend<C, DiscardedSuffixArray>>,
 );
 /// Match in the text for MultiText index.
 pub struct FMIndexMultiPiecesMatch<'a, C: Character>(
-    MatchWrapper<'a, FMIndexMultiPiecesBackend<C, ()>>,
+    MatchWrapper<'a, FMIndexMultiPiecesBackend<C, DiscardedSuffixArray>>,
 );
 
 /// MultiText index with locate support.
@@ -182,7 +193,7 @@ impl<C: Character> FMIndex<C> {
     pub fn new<T: AsRef<[C]>>(text: &Text<C, T>) -> Result<Self, Error> {
         Ok(FMIndex(SearchIndexWrapper::new(FMIndexBackend::new(
             text,
-            |_| (),
+            |_| DiscardedSuffixArray {},
         )?)))
     }
 }
@@ -207,7 +218,7 @@ impl<C: Character> RLFMIndex<C> {
     pub fn new<T: AsRef<[C]>>(text: &Text<C, T>) -> Result<Self, Error> {
         Ok(RLFMIndex(SearchIndexWrapper::new(RLFMIndexBackend::new(
             text,
-            |_| (),
+            |_| DiscardedSuffixArray {},
         )?)))
     }
 }
@@ -231,7 +242,7 @@ impl<C: Character> FMIndexMultiPieces<C> {
     /// Create a new FMIndexMultiPieces without locate support.
     pub fn new<T: AsRef<[C]>>(text: &Text<C, T>) -> Result<Self, Error> {
         Ok(FMIndexMultiPieces(SearchIndexWrapper::new(
-            FMIndexMultiPiecesBackend::new(text, |_| ())?,
+            FMIndexMultiPiecesBackend::new(text, |_| DiscardedSuffixArray {})?,
         )))
     }
 }

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -12,7 +12,6 @@
 use crate::character::Character;
 use crate::error::Error;
 use crate::fm_index::FMIndexBackend;
-use crate::heap_size::HeapSize;
 use crate::multi_pieces::FMIndexMultiPiecesBackend;
 use crate::piece::PieceId;
 use crate::rlfmi::RLFMIndexBackend;
@@ -38,6 +37,11 @@ pub trait SearchIndex<C> {
     /// Note that this includes an ending \0 (terminator) character
     /// so will be one more than the length of the text.
     fn len(&self) -> usize;
+
+    /// The size of the data used by this structure on the heap, in bytes.
+    ///
+    /// This does not include non-used pre-allocated space.
+    fn heap_size(&self) -> usize;
 }
 
 /// Trait for searching in an index that supports multiple texts.
@@ -275,12 +279,12 @@ macro_rules! impl_search_index {
             fn len(&self) -> usize {
                 self.0.len()
             }
-        }
-        impl<C: Character> HeapSize for $t {
+
             fn heap_size(&self) -> usize {
                 self.0.heap_size()
             }
         }
+
         // inherent
         impl<C: Character> $t {
             /// Search for a pattern in the text.
@@ -311,12 +315,12 @@ macro_rules! impl_search_index_with_locate {
             fn len(&self) -> usize {
                 self.0.len()
             }
-        }
-        impl<C: Character> HeapSize for $t {
+
             fn heap_size(&self) -> usize {
                 self.0.heap_size()
             }
         }
+
         // inherent
         impl<C: Character> $t {
             /// Search for a pattern in the text.

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -9,10 +9,10 @@
 // the behavior. This module only exists so we can avoid exposing implementation
 // traits.
 
-use crate::backend::HeapSize;
 use crate::character::Character;
 use crate::error::Error;
 use crate::fm_index::FMIndexBackend;
+use crate::heap_size::HeapSize;
 use crate::multi_pieces::FMIndexMultiPiecesBackend;
 use crate::piece::PieceId;
 use crate::rlfmi::RLFMIndexBackend;

--- a/src/heap_size.rs
+++ b/src/heap_size.rs
@@ -1,0 +1,10 @@
+/// Access the heap size of the structure.
+///
+/// This can be useful if you want to fine-tune the memory usage of your
+/// application.
+pub(crate) trait HeapSize {
+    /// The size of the data used by this structure on the heap, in bytes.
+    ///
+    /// This does not include non-used pre-allocated space.
+    fn heap_size(&self) -> usize;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,7 @@ mod character;
 mod error;
 mod fm_index;
 mod frontend;
+mod heap_size;
 mod multi_pieces;
 mod piece;
 mod rlfmi;
@@ -154,7 +155,6 @@ mod text;
 mod util;
 mod wrapper;
 
-pub use backend::HeapSize;
 pub use character::Character;
 pub use error::Error;
 pub use frontend::{

--- a/src/multi_pieces.rs
+++ b/src/multi_pieces.rs
@@ -96,24 +96,15 @@ where
     }
 }
 
-impl<C> HeapSize for FMIndexMultiPiecesBackend<C, ()>
+impl<C, S> HeapSize for FMIndexMultiPiecesBackend<C, S>
 where
-    C: Character,
-{
-    fn heap_size(&self) -> usize {
-        self.bw.heap_size() + self.cs.capacity() * std::mem::size_of::<u64>()
-    }
-}
-
-impl<C> HeapSize for FMIndexMultiPiecesBackend<C, SOSampledSuffixArray>
-where
-    C: Character,
+    S: HeapSize,
 {
     fn heap_size(&self) -> usize {
         self.bw.heap_size()
             + self.cs.capacity() * std::mem::size_of::<u64>()
-            + self.suffix_array.size()
             + self.doc.capacity() * std::mem::size_of::<usize>()
+            + self.suffix_array.heap_size()
     }
 }
 

--- a/src/multi_pieces.rs
+++ b/src/multi_pieces.rs
@@ -102,7 +102,7 @@ where
 {
     fn heap_size(&self) -> usize {
         self.bw.heap_size()
-            + self.cs.len() * std::mem::size_of::<u64>()
+            + self.cs.len() * std::mem::size_of::<usize>()
             + self.doc.len() * std::mem::size_of::<usize>()
             + self.suffix_array.heap_size()
     }

--- a/src/multi_pieces.rs
+++ b/src/multi_pieces.rs
@@ -102,8 +102,8 @@ where
 {
     fn heap_size(&self) -> usize {
         self.bw.heap_size()
-            + self.cs.capacity() * std::mem::size_of::<u64>()
-            + self.doc.capacity() * std::mem::size_of::<usize>()
+            + self.cs.len() * std::mem::size_of::<u64>()
+            + self.doc.len() * std::mem::size_of::<usize>()
             + self.suffix_array.heap_size()
     }
 }

--- a/src/multi_pieces.rs
+++ b/src/multi_pieces.rs
@@ -3,11 +3,11 @@ use std::ops::{Rem, Sub};
 use crate::backend::{HasMultiPieces, HasPosition, SearchIndexBackend};
 use crate::character::Character;
 use crate::error::Error;
+use crate::heap_size::HeapSize;
 use crate::piece::PieceId;
 use crate::suffix_array::sais;
 use crate::suffix_array::sample::SOSampledSuffixArray;
 use crate::text::Text;
-use crate::HeapSize;
 
 use serde::{Deserialize, Serialize};
 use vers_vecs::{BitVec, RsVec, WaveletMatrix};

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -104,7 +104,7 @@ where
         self.s.heap_size()
             + self.b.heap_size()
             + self.bp.heap_size()
-            + self.cs.len() * std::mem::size_of::<u64>()
+            + self.cs.len() * std::mem::size_of::<usize>()
             + self.suffix_array.heap_size()
     }
 }

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -95,28 +95,16 @@ where
     }
 }
 
-impl<C> HeapSize for RLFMIndexBackend<C, ()>
+impl<C, S> HeapSize for RLFMIndexBackend<C, S>
 where
-    C: Character,
+    S: HeapSize,
 {
     fn heap_size(&self) -> usize {
         self.s.heap_size()
             + self.b.heap_size()
             + self.bp.heap_size()
             + self.cs.capacity() * std::mem::size_of::<u64>()
-    }
-}
-
-impl<C> HeapSize for RLFMIndexBackend<C, SOSampledSuffixArray>
-where
-    C: Character,
-{
-    fn heap_size(&self) -> usize {
-        self.s.heap_size()
-            + self.b.heap_size()
-            + self.bp.heap_size()
-            + self.cs.capacity() * std::mem::size_of::<u64>()
-            + self.suffix_array.size()
+            + self.suffix_array.heap_size()
     }
 }
 
@@ -203,7 +191,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::wrapper::SearchIndexWrapper;
+    use crate::{suffix_array::discard::DiscardedSuffixArray, wrapper::SearchIndexWrapper};
 
     #[test]
     fn test_s() {
@@ -328,7 +316,7 @@ mod tests {
             ("si", (8, 10)),
             ("ssi", (10, 12)),
         ];
-        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| ()).unwrap();
+        let rlfmi = RLFMIndexBackend::new(&Text::new(&text), |_| DiscardedSuffixArray {}).unwrap();
 
         let wrapper = SearchIndexWrapper::new(rlfmi);
 

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -104,7 +104,7 @@ where
         self.s.heap_size()
             + self.b.heap_size()
             + self.bp.heap_size()
-            + self.cs.capacity() * std::mem::size_of::<u64>()
+            + self.cs.len() * std::mem::size_of::<u64>()
             + self.suffix_array.heap_size()
     }
 }

--- a/src/rlfmi.rs
+++ b/src/rlfmi.rs
@@ -1,6 +1,7 @@
-use crate::backend::{HasPosition, HeapSize, SearchIndexBackend};
+use crate::backend::{HasPosition, SearchIndexBackend};
 use crate::character::Character;
 use crate::error::Error;
+use crate::heap_size::HeapSize;
 use crate::suffix_array::sais;
 use crate::suffix_array::sample::SOSampledSuffixArray;
 use crate::text::Text;

--- a/src/suffix_array.rs
+++ b/src/suffix_array.rs
@@ -2,5 +2,6 @@
 //!
 //! Can also be used in sampled fashion to perform locate queries.
 
+pub mod discard;
 pub mod sais;
 pub mod sample;

--- a/src/suffix_array/discard.rs
+++ b/src/suffix_array/discard.rs
@@ -1,4 +1,4 @@
-use crate::backend::HeapSize;
+use crate::heap_size::HeapSize;
 
 pub struct DiscardedSuffixArray {}
 

--- a/src/suffix_array/discard.rs
+++ b/src/suffix_array/discard.rs
@@ -1,0 +1,9 @@
+use crate::backend::HeapSize;
+
+pub struct DiscardedSuffixArray {}
+
+impl HeapSize for DiscardedSuffixArray {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}

--- a/src/suffix_array/sample.rs
+++ b/src/suffix_array/sample.rs
@@ -1,8 +1,8 @@
 //! Sampled suffix arrays to perform locate queries.
+use crate::backend::HeapSize;
 use crate::util;
-use std::fmt;
-
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use vers_vecs::BitVec;
 
 /// A suffix array sampled by the _suffix order_ (SO) sampling strategy.
@@ -84,6 +84,12 @@ impl Default for SOSampledSuffixArray {
             sa: BitVec::new(),
             len: 0,
         }
+    }
+}
+
+impl HeapSize for SOSampledSuffixArray {
+    fn heap_size(&self) -> usize {
+        self.sa.heap_size()
     }
 }
 

--- a/src/suffix_array/sample.rs
+++ b/src/suffix_array/sample.rs
@@ -1,5 +1,5 @@
 //! Sampled suffix arrays to perform locate queries.
-use crate::backend::HeapSize;
+use crate::heap_size::HeapSize;
 use crate::util;
 use serde::{Deserialize, Serialize};
 use std::fmt;

--- a/src/suffix_array/sample.rs
+++ b/src/suffix_array/sample.rs
@@ -58,10 +58,6 @@ impl SOSampledSuffixArray {
             None
         }
     }
-
-    pub(crate) fn size(&self) -> usize {
-        self.sa.heap_size()
-    }
 }
 
 impl fmt::Debug for SOSampledSuffixArray {

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3,8 +3,9 @@
 // This makes the implementation of the frontend more regular.
 
 use crate::backend::{HasMultiPieces, HasPosition, SearchIndexBackend};
+use crate::heap_size::HeapSize;
 use crate::piece::PieceId;
-use crate::{Character, HeapSize};
+use crate::Character;
 
 pub(crate) struct SearchIndexWrapper<B>(B)
 where

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -6,8 +6,8 @@ fn len<T: SearchIndex<u8>>(index: &T) -> usize {
     index.len()
 }
 
-fn size<T: SearchIndex<u8>>(_: &T) -> usize {
-    todo!("implement size function");
+fn size<T: SearchIndex<u8>>(index: &T) -> usize {
+    index.heap_size()
 }
 
 #[test]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -1,15 +1,13 @@
 // tests that exercise the public API, especially the traits
 
-use fm_index::{
-    FMIndex, FMIndexWithLocate, HeapSize, RLFMIndex, RLFMIndexWithLocate, SearchIndex, Text,
-};
+use fm_index::{FMIndex, FMIndexWithLocate, RLFMIndex, RLFMIndexWithLocate, SearchIndex, Text};
 
 fn len<T: SearchIndex<u8>>(index: &T) -> usize {
     index.len()
 }
 
-fn size<T: HeapSize>(t: &T) -> usize {
-    t.heap_size()
+fn size<T: SearchIndex<u8>>(_: &T) -> usize {
+    todo!("implement size function");
 }
 
 #[test]


### PR DESCRIPTION
This PR refactors how each struct implements `heap_size` and changes its behavior.

- `HeapSize` is not offered as a public API anymore. The frontend indexes implement `heap_size` required by `SearchIndex` trait. This idea originates from #61, while we keep `HeapSize` itself as an internal trait for backend indexes and sampled suffix arrays.
- `()` type in the backend indexes is replaced with a new empty type `DiscardedSuffixArray`, so that we can implement `HeapSize` for the backend indexes consistently.
- `heap_size` does not count the pre-allocated space anymore; that is, `Vec::len` is favored rather than `Vec::capacity`. Finally our `heap_size` behaves the same as vers-vecs (ref: #71)