### PR TITLE
Remove SearchWithLocate trait

### DIFF
--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -76,12 +76,6 @@ pub trait Search<'a, C> {
     fn iter_matches(&'a self) -> impl Iterator<Item = Self::Match> + 'a;
 }
 
-/// The result of a search that also has locate support.
-pub trait SearchWithLocate<'a, C>: Search<'a, C> {
-    /// List the position of all occurrences.
-    fn locate(&self) -> Vec<u64>;
-}
-
 /// A match in the text.
 pub trait Match<'a, C> {
     /// Iterate over the characters of the match.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ pub use frontend::{
     FMIndexSearchWithLocate, FMIndexWithLocate, Match, MatchWithLocate, MatchWithPieceId,
     RLFMIndex, RLFMIndexMatch, RLFMIndexMatchWithLocate, RLFMIndexSearch,
     RLFMIndexSearchWithLocate, RLFMIndexWithLocate, Search, SearchIndex,
-    SearchIndexWithMultiPieces, SearchWithLocate,
+    SearchIndexWithMultiPieces,
 };
 pub use piece::PieceId;
 pub use text::Text;


### PR DESCRIPTION
Related: #79

This is a fix-up for #81 that removes `SearchWithLocate` trait. The trait is not implemented anymore.