### PR TITLE
Update readme dependencies version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`.
 
 ```toml
 [dependencies]
-fm-index = "0.2"
+fm-index = "0.3.0"
 ```
 
 ## Example

--- a/release.toml
+++ b/release.toml
@@ -4,4 +4,5 @@ pre-release-replacements = [
   {file="CHANGES.md", search="ReleaseDate", replace="{{date}}"},
   {file="CHANGES.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate", exactly=1},
   {file="CHANGES.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/ajalab/fm-index/compare/{{tag_name}}...HEAD", exactly=1},
+  {file="README.md", search="fm-index = .*", replace="{{crate_name}} = \"{{version}}\""},
 ]


### PR DESCRIPTION
This updates dependency declaration of `fm-index` crate in `README.md`. Also, it ensures that the version will be updated automatically when running `cargo release`.